### PR TITLE
Fixed a typo in environment variable name

### DIFF
--- a/cross-compiling/README.md
+++ b/cross-compiling/README.md
@@ -54,7 +54,7 @@ For example you can run:
 
 ```
 export TARGET=raspbian
-export ROS2_BRANCH=dashing
+export ROS2_DISTRO=dashing
 bash automatic_cross_compile.sh
 ```
 


### PR DESCRIPTION
The script  automatic_cross_compile.sh expects ROS2_DISTRO to be set instead of ROS2_BRANCH