### PR TITLE
Fix the build error for example and test in performance_test.

### DIFF
--- a/performances/performance_test/examples/CMakeLists.txt
+++ b/performances/performance_test/examples/CMakeLists.txt
@@ -1,34 +1,28 @@
 
 
 
+find_package(performance_test REQUIRED)
 
 add_executable(publisher_nodes_main publisher_nodes_main.cpp)
 ament_target_dependencies(publisher_nodes_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(publisher_nodes_main ${LIBRARY_NAME})
 
 add_executable(subscriber_nodes_main subscriber_nodes_main.cpp)
 ament_target_dependencies(subscriber_nodes_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(subscriber_nodes_main ${LIBRARY_NAME})
 
 add_executable(client_nodes_main client_nodes_main.cpp)
 ament_target_dependencies(client_nodes_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(client_nodes_main ${LIBRARY_NAME})
 
 add_executable(server_nodes_main server_nodes_main.cpp)
 ament_target_dependencies(server_nodes_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(server_nodes_main ${LIBRARY_NAME})
 
 add_executable(simple_pub_sub_main simple_pub_sub_main.cpp)
 ament_target_dependencies(simple_pub_sub_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(simple_pub_sub_main ${LIBRARY_NAME})
 
 add_executable(simple_client_service_main simple_client_service_main.cpp)
 ament_target_dependencies(simple_client_service_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(simple_client_service_main ${LIBRARY_NAME})
 
 add_executable(json_system_main json_system_main.cpp)
 ament_target_dependencies(json_system_main rclcpp performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(json_system_main ${LIBRARY_NAME})
 
 install(TARGETS
   publisher_nodes_main

--- a/performances/performance_test/test/CMakeLists.txt
+++ b/performances/performance_test/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 find_package(ament_lint_auto REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
+find_package(performance_test REQUIRED)
 
 ament_lint_auto_find_test_dependencies()
 
@@ -10,16 +11,12 @@ ament_target_dependencies(stat_test ${LIBRARY_DEPENDENCIES})
 
 ament_add_gtest(tracker_test tracker_test.cpp)
 ament_target_dependencies(tracker_test performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(tracker_test ${LIBRARY_NAME})
 
 ament_add_gtest(node_test node_test.cpp)
 ament_target_dependencies(node_test performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(node_test ${LIBRARY_NAME})
 
 ament_add_gtest(system_test system_test.cpp)
 ament_target_dependencies(system_test performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(system_test ${LIBRARY_NAME})
 
 ament_add_gtest(factory_test factory_test.cpp)
 ament_target_dependencies(factory_test performance_test_msgs ${LIBRARY_NAME})
-target_link_libraries(factory_test ${LIBRARY_NAME})


### PR DESCRIPTION
I met build error while building performance test.
The reason is that we should add `find_package` first before addling `${LIBRARY_NAME}` to `ament_target_dependencies`.
By the way, I think we just need either `ament_target_dependencies` or `target_link_libraries`.
It's unnecessary to use both.