### PR TITLE
Update cross_compile.sh

### DIFF
--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -18,7 +18,6 @@ colcon \
     build \
     --merge-install \
     --cmake-force-configure \
-    --executor sequential \
     --cmake-args \
     -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_PATH \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
@@ -27,5 +26,3 @@ colcon \
 
 
 # --merge-install is used to avoid creation of nested install dirs for each package
-# --executtor sequential is used because parallel build fails in random ways
-


### PR DESCRIPTION
We are currently cross-compiling in "sequential" mode.

I was using this option with ROS 2 bouncy, I assume that now the problems with parallel build have been fixed.

I already removed it locally and I haven't seen failures lately.