### PR TITLE
use floating point division to compute frequency correctly

### DIFF
--- a/performances/performance_test/include/performance_test/ros2/node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/node.hpp
@@ -265,7 +265,7 @@ private:
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher
-          msg->header.frequency = 1000 / period.count();
+          msg->header.frequency = 1000.0 / period.count();
           // set the tracking count for this message
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing
@@ -282,7 +282,7 @@ private:
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher
-          msg->header.frequency = 1000 / period.count();
+          msg->header.frequency = 1000.0 / period.count();
           // set the tracking count for this message
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing


### PR DESCRIPTION
Previously the code was performing an integer division.
That frequency value is sent from the publisher to the subscription to compute metrics in a decentralized way.

This resulted in sending a frequency of 0 whenever the period was higher than 1 second, thus resulting in 100% messages being detected as late