### PR TITLE
updates for better external profiling

### DIFF
--- a/performances/benchmark/src/benchmark.cpp
+++ b/performances/benchmark/src/benchmark.cpp
@@ -38,8 +38,9 @@ int main(int argc, char** argv)
     std::cout << "Intra-process-communication: " << (options.ipc ? "on" : "off") << std::endl;
     std::cout << "Run test for: " << options.duration_sec << " seconds" << std::endl;
     std::cout << "Sampling resources every " << options.resources_sampling_per_ms << "ms" << std::endl;
+    std::cout << "Logging events statistics: " << (options.tracking_options.is_enabled ? "on" : "off") << std::endl;
     std::cout << "Start test" << std::endl;
-
+    
     std::string topology_json;
 
     pid_t pid = getpid();
@@ -82,7 +83,10 @@ int main(int argc, char** argv)
 
     int executors = 0; // set to 1 if you want to add all nodes to the same executor
     performance_test::System ros2_system(executors);
-    ros2_system.enable_events_logger(events_output_path);
+    
+    if (options.tracking_options.is_enabled) {
+        ros2_system.enable_events_logger(events_output_path);    
+    }
 
     // Load topology from json file
     performance_test::TemplateFactory factory = performance_test::TemplateFactory(options.ipc);

--- a/performances/performance_test/include/cli/options.hpp
+++ b/performances/performance_test/include/cli/options.hpp
@@ -26,6 +26,7 @@ public:
         ipc = true;
         duration_sec = 5;
         resources_sampling_per_ms = 500;
+	tracking_options.is_enabled = true;
         tracking_options.late_percentage = 20;
         tracking_options.late_absolute_us = 5000;
         tracking_options.too_late_percentage = 100;
@@ -44,6 +45,7 @@ public:
       cxxopts::Options options(argv[0], "ROS2 performance benchmark");
 
       std::string ipc_option;
+      std::string tracking_enabled_option;
       options.positional_help("FILE [FILE...]").show_positional_help();
       options.parse_positional({"topology"});
       options.add_options()
@@ -55,6 +57,8 @@ public:
       ("t,time", "test duration", cxxopts::value<int>(duration_sec)->default_value(std::to_string(duration_sec)),"sec")
       ("s, sampling", "resources sampling period",
         cxxopts::value<int>(resources_sampling_per_ms)->default_value(std::to_string(resources_sampling_per_ms)),"msec")
+      ("tracking", "compute and logs detailed statistics and events",
+        cxxopts::value<std::string>(tracking_enabled_option)->default_value(tracking_options.is_enabled ? "on" : "off"),"on/off")
       ("late-percentage", "a msg with greater latency than this percentage of the msg publishing period is considered late",
         cxxopts::value<int>(tracking_options.late_percentage)->default_value(std::to_string(tracking_options.late_percentage)),"%")
       ("late-absolute", "a msg with greater latency than this is considered late",
@@ -81,12 +85,17 @@ public:
           throw cxxopts::argument_incorrect_type(ipc_option);
         }
 
+        if (tracking_enabled_option != "off" && tracking_enabled_option != "on") {
+          throw cxxopts::argument_incorrect_type(tracking_enabled_option);
+        }
+
       } catch (const cxxopts::OptionException& e) {
         std::cout << "Error parsing options. " << e.what() << std::endl;
         exit(1);
       }
 
       ipc = (ipc_option == "on" ? true : false);
+      tracking_options.is_enabled = (tracking_enabled_option == "on" ? true : false);
     }
 
     bool ipc;

--- a/performances/performance_test/src/ros2/system.cpp
+++ b/performances/performance_test/src/ros2/system.cpp
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <map>
+#include <pthread.h>
 
 #include "performance_test/ros2/system.hpp"
 #include "performance_test/ros2/names_utilities.hpp"
@@ -81,6 +82,7 @@ void performance_test::System::spin(int duration_sec, bool wait_for_discovery)
         std::thread thread([&](){
             _executor->spin();
         });
+        pthread_setname_np(thread.native_handle(), "executor");
         thread.detach();
     }
     else{
@@ -90,6 +92,7 @@ void performance_test::System::spin(int duration_sec, bool wait_for_discovery)
             ex->add_node(n);
             // Spin each executor in a different thread
             std::thread a([=]() { ex->spin(); });
+            pthread_setname_np(thread.native_handle(), n->get_name());
             a.detach();
             _executors_vec.push_back(ex);
         }

--- a/performances/performance_test/src/ros2/system.cpp
+++ b/performances/performance_test/src/ros2/system.cpp
@@ -91,9 +91,9 @@ void performance_test::System::spin(int duration_sec, bool wait_for_discovery)
             auto ex = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
             ex->add_node(n);
             // Spin each executor in a different thread
-            std::thread a([=]() { ex->spin(); });
+            std::thread thread([=]() { ex->spin(); });
             pthread_setname_np(thread.native_handle(), n->get_name());
-            a.detach();
+            thread.detach();
             _executors_vec.push_back(ex);
         }
     }


### PR DESCRIPTION
Some updates to facilitate external profiling of this application:
 - give names to threads
 - add command line option `--tracker off` to disable events logging (e.g. late and too late computation)