### PR TITLE
add executor_id flag to json to split nodes into different executors

### DIFF
--- a/performances/benchmark/src/benchmark.cpp
+++ b/performances/benchmark/src/benchmark.cpp
@@ -81,9 +81,8 @@ int main(int argc, char** argv)
 
     rclcpp::init(argc, argv);
 
-    int executors = 0; // set to 1 if you want to add all nodes to the same executor
-    performance_test::System ros2_system(executors);
-    
+    performance_test::System ros2_system;
+
     if (options.tracking_options.is_enabled) {
         ros2_system.enable_events_logger(events_output_path);    
     }

--- a/performances/performance_test/include/performance_test/ros2/node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/node.hpp
@@ -41,10 +41,12 @@ friend class System;
 
 public:
 
-  Node(const std::string& name, const std::string& ros2_namespace = "", bool ipc = true)
+  Node(const std::string& name, const std::string& ros2_namespace = "", bool ipc = true, int executor_id = 0)
     : rclcpp::Node(name, ros2_namespace, rclcpp::NodeOptions().use_intra_process_comms(ipc))
   {
-    RCLCPP_INFO(this->get_logger(), "Node %s created", name.c_str());
+    m_executor_id = executor_id;
+
+    RCLCPP_INFO(this->get_logger(), "Node %s created with executor id %d", name.c_str(), m_executor_id);
   }
 
 
@@ -245,6 +247,10 @@ public:
     _events_logger = ev;
   }
 
+  int get_executor_id()
+  {
+    return m_executor_id;
+  }
 
 private:
 
@@ -447,5 +453,6 @@ private:
 
   std::shared_ptr<EventsLogger> _events_logger;
 
+  int m_executor_id = 0;
 };
 }

--- a/performances/performance_test/include/performance_test/ros2/system.hpp
+++ b/performances/performance_test/include/performance_test/ros2/system.hpp
@@ -17,11 +17,18 @@
 
 namespace performance_test {
 
+struct NamedExecutor
+{
+    rclcpp::executor::Executor::SharedPtr executor;
+    std::string name;
+};
+
+
 class System
 {
 public:
 
-  System(int executor_id = 0);
+  System() = default;
 
   void add_node(std::vector<std::shared_ptr<Node>> nodes);
 
@@ -59,8 +66,7 @@ private:
 
   std::vector<std::shared_ptr<Node>> _nodes;
 
-  rclcpp::executor::Executor::SharedPtr _executor;
-  std::vector<rclcpp::executors::SingleThreadedExecutor::SharedPtr> _executors_vec;
+  std::map<int, NamedExecutor> _executors_map;
 
 
   std::shared_ptr<EventsLogger> _events_logger;

--- a/performances/performance_test/test/test_system.cpp
+++ b/performances/performance_test/test/test_system.cpp
@@ -31,14 +31,12 @@ TEST_F(TestSystem, SystemAddNodesTest)
     auto node_3 = std::make_shared<performance_test::Node>("node_3");
     std::vector<std::shared_ptr<performance_test::Node>> nodes_vec = {node_2, node_3};
 
-    int executors = 0;
-    performance_test::System separate_threads_system(executors);
+    performance_test::System separate_threads_system;
 
     separate_threads_system.add_node(node_1);
     separate_threads_system.add_node(nodes_vec);
 
-    executors = 1;
-    performance_test::System single_executor_system(executors);
+    performance_test::System single_executor_system;
 
     single_executor_system.add_node(node_1);
     single_executor_system.add_node(nodes_vec);

--- a/performances/performance_test_factory/examples/client_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/client_nodes_main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char ** argv)
     int n_services = 1;
     std::string msg_type = "stamped10b";
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -53,8 +52,6 @@ int main(int argc, char ** argv)
         cxxopts::value<std::string>(msg_type)->default_value(msg_type))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -96,7 +93,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> client_nodes =

--- a/performances/performance_test_factory/examples/json_system_main.cpp
+++ b/performances/performance_test_factory/examples/json_system_main.cpp
@@ -81,8 +81,7 @@ int main(int argc, char** argv)
     rclcpp::init(argc, argv);
 
     // Architecture
-    int executors = 0; // set to 1 if you want to add all nodes to the same executor
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_output_path);
 
     performance_test::TemplateFactory factory(use_ipc);

--- a/performances/performance_test_factory/examples/publisher_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/publisher_nodes_main.cpp
@@ -30,7 +30,6 @@ int main(int argc, char ** argv)
     std::string msg_type = "stamped10b";
     int msg_size = 0;
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -56,8 +55,6 @@ int main(int argc, char ** argv)
         cxxopts::value<int>(msg_size)->default_value(std::to_string(msg_size)))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -99,7 +96,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> pub_nodes =

--- a/performances/performance_test_factory/examples/server_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/server_nodes_main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char ** argv)
     int n_services = 1;
     std::string msg_type = "stamped10b";
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -53,8 +52,6 @@ int main(int argc, char ** argv)
         cxxopts::value<std::string>(msg_type)->default_value(msg_type))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -96,7 +93,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> server_nodes =

--- a/performances/performance_test_factory/examples/simple_client_service_main.cpp
+++ b/performances/performance_test_factory/examples/simple_client_service_main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char ** argv)
     int n_services = 1;
     std::string msg_type = "stamped10b";
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -53,8 +52,6 @@ int main(int argc, char ** argv)
         cxxopts::value<std::string>(msg_type)->default_value(msg_type))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -96,7 +93,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> server_nodes =

--- a/performances/performance_test_factory/examples/simple_pub_sub_main.cpp
+++ b/performances/performance_test_factory/examples/simple_pub_sub_main.cpp
@@ -30,7 +30,6 @@ int main(int argc, char ** argv)
     std::string msg_type = "stamped10b";
     int msg_size = 0;
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -56,8 +55,6 @@ int main(int argc, char ** argv)
         cxxopts::value<int>(msg_size)->default_value(std::to_string(msg_size)))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -99,7 +96,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> pub_nodes =

--- a/performances/performance_test_factory/examples/subscriber_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/subscriber_nodes_main.cpp
@@ -30,7 +30,6 @@ int main(int argc, char ** argv)
     std::string msg_type = "stamped10b";
     int msg_size = 0;
     float frequency = 10;
-    int executors = 0;
     int use_ipc = 0;
     std::string ros_namespace = "";
     int experiment_duration = 5;
@@ -56,8 +55,6 @@ int main(int argc, char ** argv)
         cxxopts::value<int>(msg_size)->default_value(std::to_string(msg_size)))
     ("f,frequency", "Request frequency",
         cxxopts::value<float>(frequency)->default_value(std::to_string(frequency)))
-    ("executors", "Threading model: 0 each node has its own thread, 1 all nodes are in the same executor",
-        cxxopts::value<int>(executors)->default_value(std::to_string(executors)))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
         cxxopts::value<int>(use_ipc)->default_value(std::to_string(use_ipc)))
     ("ros_namespace", "Create every node under this namespace",
@@ -99,7 +96,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, verbose, ros_namespace);
-    performance_test::System ros2_system(executors);
+    performance_test::System ros2_system;
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> sub_nodes =

--- a/performances/performance_test_factory/include/performance_test_factory/factory.hpp
+++ b/performances/performance_test_factory/include/performance_test_factory/factory.hpp
@@ -39,7 +39,8 @@ class TemplateFactory {
             std::string name,
             bool use_ipc = true,
             bool verbose = false,
-            std::string ros2_namespace = "");
+            std::string ros2_namespace = "",
+            int executor_id = 0);
 
         std::vector<std::shared_ptr<Node>> create_subscriber_nodes(
             int start_id,

--- a/performances/performance_test_factory/src/factory.cpp
+++ b/performances/performance_test_factory/src/factory.cpp
@@ -25,10 +25,11 @@ std::shared_ptr<performance_test::Node> performance_test::TemplateFactory::creat
     std::string name,
     bool use_ipc,
     bool verbose,
-    std::string ros2_namespace)
+    std::string ros2_namespace,
+    int executor_id)
 {
 
-    auto node = std::make_shared<performance_test::Node>(name, ros2_namespace, use_ipc);
+    auto node = std::make_shared<performance_test::Node>(name, ros2_namespace, use_ipc, executor_id);
 
     if (verbose){
         auto ret = rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
@@ -330,7 +331,13 @@ std::shared_ptr<performance_test::Node> performance_test::TemplateFactory::creat
 {
 
     auto node_name = std::string(node_json["node_name"]) + suffix;
-    auto node = this->create_node(node_name, _use_ipc, _verbose_mode, _ros2_namespace);
+
+    int executor_id = 0;
+    if (node_json.find("executor_id") != node_json.end()) {
+        executor_id = node_json["executor_id"];
+    }
+
+    auto node = this->create_node(node_name, _use_ipc, _verbose_mode, _ros2_namespace, executor_id);
 
     return node;
 }


### PR DESCRIPTION
This PR allows to use a new value in the json topology: `executor_id` specified for each node.

Nodes with the same id will be added to the same executor.

```
      {
        "node_name": "montreal",
        "publishers": [
              {"topic_name": "amazon", "msg_type": "stamped9_float32", "period_ms": 10}
            ],
        "executor_id":1
      }
```