### PR TITLE
use rcutils instead of libpoco for loading shared libraries

### DIFF
--- a/performances/performance_test_factory/CMakeLists.txt
+++ b/performances/performance_test_factory/CMakeLists.txt
@@ -12,10 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-# provides FindPoco.cmake and Poco on platforms without it
-find_package(poco_vendor)
-find_package(Poco COMPONENTS Foundation REQUIRED)
-
+find_package(rcutils REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(performance_test REQUIRED)
 
@@ -31,6 +28,7 @@ set (LIBRARY_DEPENDENCIES
 
 set(LIBRARY_SRC
   src/factory.cpp
+  src/load_plugins.cpp
 )
 
 set(LIBRARY_NAME ${PROJECT_NAME})

--- a/performances/performance_test_factory/CMakeLists.txt
+++ b/performances/performance_test_factory/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-find_package(rcutils REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(performance_test REQUIRED)
 
@@ -22,6 +22,7 @@ include_directories(
 )
 
 set (LIBRARY_DEPENDENCIES
+  rcpputils
   rclcpp
   performance_test
 )

--- a/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
+++ b/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
@@ -7,113 +7,25 @@
  *  You may use, distribute and modify this code under the BSD-3-Clause license.
  */
 
-#include <cstddef>
-#include <cstdio>
-#include <cstring>
 
-#include <list>
+#pragma once
+
 #include <string>
 
-#include <fstream>
-#include <iostream>
-#include <sstream>
+#include <rcutils/shared_library.h>
 
-#include "Poco/SharedLibrary.h"
+namespace performance_test {
 
+std::string get_env_var(const char * env_var);
 
-std::string get_env_var(const char * env_var)
-{
-  char * value = nullptr;
-  value = getenv(env_var);
-  std::string value_str = "";
-  if (value) {
-    value_str = value;
-  }
-  // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
-  return value_str;
-}
+std::list<std::string> split(const std::string & value, const char delimiter);
 
-std::list<std::string> split(const std::string & value, const char delimiter)
-{
-  std::list<std::string> list;
-  std::istringstream ss(value);
-  std::string s;
-  while (std::getline(ss, s, delimiter)) {
-    list.push_back(s);
-  }
+bool is_file_exist(const char * filename);
 
-  return list;
-}
+std::string find_library_path(const std::string & library_name);
 
-bool is_file_exist(const char * filename)
-{
-  std::ifstream h(filename);
-  return h.good();
-}
+std::string get_library_name(std::string msg_type);
 
-std::string find_library_path(const std::string & library_name)
-{
-  const char * env_var = "LD_LIBRARY_PATH";
-  char separator = ':';
-  const char * filename_prefix = "lib";
-  const char * filename_extension = ".so";
+rcutils_shared_library_t get_library(std::string msg_type);
 
-  std::string search_path = get_env_var(env_var);
-  std::list<std::string> search_paths = split(search_path, separator);
-
-  std::string filename = filename_prefix;
-  filename += library_name + filename_extension;
-
-  for (auto it : search_paths) {
-    std::string path = it + "/" + filename;
-    if (is_file_exist(path.c_str())) {
-      return path;
-    }
-  }
-  return "";
-}
-
-
-std::string
-get_library_name(std::string msg_type)
-{
-  const std::string DEFAULT_LIBRARY_NAME = "irobot_interfaces_plugin";
-  std::string namespace_delimiter = "::";
-
-  std::string library_name;
-  //std::string msg_name;
-  size_t pos = msg_type.find(namespace_delimiter);
-  if (pos == std::string::npos) {
-    library_name = DEFAULT_LIBRARY_NAME + "_implementation";
-    //msg_name = msg_type;
-  } else {
-    library_name = msg_type.substr(0, pos) + "_implementation";
-    //msg_name = msg_type.substr(pos + namespace_delimiter.length(), msg_type.length());
-  }
-
-  return library_name;
-}
-
-
-Poco::SharedLibrary *
-get_library(std::string msg_type)
-{
-  Poco::SharedLibrary * lib = nullptr;
-
-  std::string library_name = get_library_name(msg_type);
-
-  std::string library_path = find_library_path(library_name);
-  if (library_path.empty()) {
-    std::cout<<"Error! library path is empty "<<std::endl;
-    return nullptr;
-  }
-
-  try {
-    lib = new Poco::SharedLibrary(library_path);
-  } catch (...) {
-    std::cout<<"got exception loading library"<<std::endl;
-    return nullptr;
-  }
-
-  return lib;
 }

--- a/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
+++ b/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
@@ -10,22 +10,13 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
-#include <rcutils/shared_library.h>
+#include <rcpputils/shared_library.hpp>
 
 namespace performance_test {
 
-std::string get_env_var(const char * env_var);
-
-std::list<std::string> split(const std::string & value, const char delimiter);
-
-bool is_file_exist(const char * filename);
-
-std::string find_library_path(const std::string & library_name);
-
-std::string get_library_name(std::string msg_type);
-
-rcutils_shared_library_t get_library(std::string msg_type);
+std::shared_ptr<rcpputils::SharedLibrary> get_library(std::string msg_type);
 
 }

--- a/performances/performance_test_factory/package.xml
+++ b/performances/performance_test_factory/package.xml
@@ -10,16 +10,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>rcutils</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>performance_test</build_depend>
   <build_depend>irobot_interfaces_plugin</build_depend>
 
+  <exec_depend>rcutils</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>performance_test</exec_depend>
   <exec_depend>irobot_interfaces_plugin</exec_depend>
-
-  <depend>libpoco-dev</depend>
-  <depend>poco_vendor</depend>
 
   <group_depend>performance_test_factory_plugins</group_depend>
 

--- a/performances/performance_test_factory/package.xml
+++ b/performances/performance_test_factory/package.xml
@@ -10,12 +10,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rcutils</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>performance_test</build_depend>
   <build_depend>irobot_interfaces_plugin</build_depend>
 
-  <exec_depend>rcutils</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>performance_test</exec_depend>
   <exec_depend>irobot_interfaces_plugin</exec_depend>

--- a/performances/performance_test_factory/src/factory.cpp
+++ b/performances/performance_test_factory/src/factory.cpp
@@ -177,11 +177,7 @@ void performance_test::TemplateFactory::add_subscriber_from_strings(
     msg_pass_by_t msg_pass_by,
     rmw_qos_profile_t custom_qos_profile)
 {
-    Poco::SharedLibrary * library = get_library(msg_type);
-
-    if (library == nullptr) {
-      std::cout<<"Error! Library is nullptr"<<std::endl;
-    }
+    rcutils_shared_library_t library = performance_test::get_library(msg_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -191,9 +187,9 @@ void performance_test::TemplateFactory::add_subscriber_from_strings(
       msg_pass_by_t,
       rmw_qos_profile_t);
 
-		function_impl_t add_subscriber_impl = (function_impl_t)library->getSymbol("add_subscriber_impl");
-		add_subscriber_impl(n, msg_type, topic_name, tracking_options, msg_pass_by, custom_qos_profile);
-		library->unload();
+    function_impl_t add_subscriber_impl = (function_impl_t)rcutils_get_symbol(&library, "add_subscriber_impl");
+    add_subscriber_impl(n, msg_type, topic_name, tracking_options, msg_pass_by, custom_qos_profile);
+    rcutils_unload_shared_library(&library);
 }
 
 
@@ -206,11 +202,7 @@ void performance_test::TemplateFactory::add_periodic_publisher_from_strings(
     std::chrono::milliseconds period_ms,
     size_t msg_size)
 {
-    Poco::SharedLibrary * library = get_library(msg_type);
-
-    if (library == nullptr) {
-      std::cout<<"Error! Library is nullptr"<<std::endl;
-    }
+    rcutils_shared_library_t library = performance_test::get_library(msg_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -221,9 +213,9 @@ void performance_test::TemplateFactory::add_periodic_publisher_from_strings(
       std::chrono::milliseconds,
       size_t);
 
-		function_impl_t add_publisher_impl = (function_impl_t)library->getSymbol("add_publisher_impl");
-		add_publisher_impl(n, msg_type, topic_name, msg_pass_by, custom_qos_profile, period_ms, msg_size);
-		library->unload();
+    function_impl_t add_publisher_impl = (function_impl_t)rcutils_get_symbol(&library, "add_publisher_impl");
+    add_publisher_impl(n, msg_type, topic_name, msg_pass_by, custom_qos_profile, period_ms, msg_size);
+    rcutils_unload_shared_library(&library);
 }
 
 
@@ -233,11 +225,7 @@ void performance_test::TemplateFactory::add_server_from_strings(
     std::string service_name,
     rmw_qos_profile_t custom_qos_profile)
 {
-    Poco::SharedLibrary * library = get_library(srv_type);
-
-    if (library == nullptr) {
-      std::cout<<"Error! Library is nullptr"<<std::endl;
-    }
+    rcutils_shared_library_t library = performance_test::get_library(srv_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -246,9 +234,9 @@ void performance_test::TemplateFactory::add_server_from_strings(
       rmw_qos_profile_t
     );
 
-		function_impl_t add_server_impl = (function_impl_t)library->getSymbol("add_server_impl");
-		add_server_impl(n, srv_type, service_name, custom_qos_profile);
-		library->unload();
+    function_impl_t add_server_impl = (function_impl_t)rcutils_get_symbol(&library, "add_server_impl");
+    add_server_impl(n, srv_type, service_name, custom_qos_profile);
+    rcutils_unload_shared_library(&library);
 }
 
 
@@ -259,11 +247,7 @@ void performance_test::TemplateFactory::add_periodic_client_from_strings(
     rmw_qos_profile_t custom_qos_profile,
     std::chrono::milliseconds period_ms)
 {
-    Poco::SharedLibrary * library = get_library(srv_type);
-
-    if (library == nullptr) {
-      std::cout<<"Error! Library is nullptr"<<std::endl;
-    }
+    rcutils_shared_library_t library = performance_test::get_library(srv_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -273,9 +257,9 @@ void performance_test::TemplateFactory::add_periodic_client_from_strings(
       std::chrono::milliseconds period_ms
     );
 
-		function_impl_t add_client_impl = (function_impl_t)library->getSymbol("add_client_impl");
-		add_client_impl(n, srv_type, service_name, custom_qos_profile, period_ms);
-		library->unload();
+    function_impl_t add_client_impl = (function_impl_t)rcutils_get_symbol(&library, "add_client_impl");
+    add_client_impl(n, srv_type, service_name, custom_qos_profile, period_ms);
+    rcutils_unload_shared_library(&library);
 }
 
 

--- a/performances/performance_test_factory/src/factory.cpp
+++ b/performances/performance_test_factory/src/factory.cpp
@@ -177,7 +177,7 @@ void performance_test::TemplateFactory::add_subscriber_from_strings(
     msg_pass_by_t msg_pass_by,
     rmw_qos_profile_t custom_qos_profile)
 {
-    rcutils_shared_library_t library = performance_test::get_library(msg_type);
+    auto library = performance_test::get_library(msg_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -187,9 +187,8 @@ void performance_test::TemplateFactory::add_subscriber_from_strings(
       msg_pass_by_t,
       rmw_qos_profile_t);
 
-    function_impl_t add_subscriber_impl = (function_impl_t)rcutils_get_symbol(&library, "add_subscriber_impl");
+    function_impl_t add_subscriber_impl = (function_impl_t)library->get_symbol("add_subscriber_impl");
     add_subscriber_impl(n, msg_type, topic_name, tracking_options, msg_pass_by, custom_qos_profile);
-    rcutils_unload_shared_library(&library);
 }
 
 
@@ -202,7 +201,7 @@ void performance_test::TemplateFactory::add_periodic_publisher_from_strings(
     std::chrono::microseconds period,
     size_t msg_size)
 {
-    rcutils_shared_library_t library = performance_test::get_library(msg_type);
+    auto library = performance_test::get_library(msg_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -213,9 +212,8 @@ void performance_test::TemplateFactory::add_periodic_publisher_from_strings(
       std::chrono::microseconds,
       size_t);
 
-    function_impl_t add_publisher_impl = (function_impl_t)rcutils_get_symbol(&library, "add_publisher_impl");
+    function_impl_t add_publisher_impl = (function_impl_t)library->get_symbol("add_publisher_impl");
     add_publisher_impl(n, msg_type, topic_name, msg_pass_by, custom_qos_profile, period, msg_size);
-    rcutils_unload_shared_library(&library);
 }
 
 
@@ -225,7 +223,7 @@ void performance_test::TemplateFactory::add_server_from_strings(
     std::string service_name,
     rmw_qos_profile_t custom_qos_profile)
 {
-    rcutils_shared_library_t library = performance_test::get_library(srv_type);
+    auto library = performance_test::get_library(srv_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -234,9 +232,8 @@ void performance_test::TemplateFactory::add_server_from_strings(
       rmw_qos_profile_t
     );
 
-    function_impl_t add_server_impl = (function_impl_t)rcutils_get_symbol(&library, "add_server_impl");
+    function_impl_t add_server_impl = (function_impl_t)library->get_symbol("add_server_impl");
     add_server_impl(n, srv_type, service_name, custom_qos_profile);
-    rcutils_unload_shared_library(&library);
 }
 
 
@@ -247,7 +244,7 @@ void performance_test::TemplateFactory::add_periodic_client_from_strings(
     rmw_qos_profile_t custom_qos_profile,
     std::chrono::microseconds period)
 {
-    rcutils_shared_library_t library = performance_test::get_library(srv_type);
+    auto library = performance_test::get_library(srv_type);
 
     typedef void (*function_impl_t)(
       std::shared_ptr<performance_test::Node>,
@@ -257,9 +254,8 @@ void performance_test::TemplateFactory::add_periodic_client_from_strings(
       std::chrono::microseconds period
     );
 
-    function_impl_t add_client_impl = (function_impl_t)rcutils_get_symbol(&library, "add_client_impl");
+    function_impl_t add_client_impl = (function_impl_t)library->get_symbol("add_client_impl");
     add_client_impl(n, srv_type, service_name, custom_qos_profile, period);
-    rcutils_unload_shared_library(&library);
 }
 
 

--- a/performances/performance_test_factory/src/load_plugins.cpp
+++ b/performances/performance_test_factory/src/load_plugins.cpp
@@ -1,0 +1,116 @@
+/* Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, iRobot ROS
+ *  All rights reserved.
+ *
+ *  This file is part of ros2-performance, which is released under BSD-3-Clause.
+ *  You may use, distribute and modify this code under the BSD-3-Clause license.
+ */
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+#include <list>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#include "performance_test_factory/load_plugins.hpp"
+
+using namespace performance_test;
+
+std::string performance_test::get_env_var(const char * env_var)
+{
+  char * value = nullptr;
+  value = getenv(env_var);
+  std::string value_str = "";
+  if (value) {
+    value_str = value;
+  }
+  // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
+  return value_str;
+}
+
+std::list<std::string> performance_test::split(const std::string & value, const char delimiter)
+{
+  std::list<std::string> list;
+  std::istringstream ss(value);
+  std::string s;
+  while (std::getline(ss, s, delimiter)) {
+    list.push_back(s);
+  }
+
+  return list;
+}
+
+bool performance_test::is_file_exist(const char * filename)
+{
+  std::ifstream h(filename);
+  return h.good();
+}
+
+std::string performance_test::find_library_path(const std::string & library_name)
+{
+  const char * env_var = "LD_LIBRARY_PATH";
+  char separator = ':';
+  const char * filename_prefix = "lib";
+  const char * filename_extension = ".so";
+
+  std::string search_path = get_env_var(env_var);
+  std::list<std::string> search_paths = split(search_path, separator);
+
+  std::string filename = filename_prefix;
+  filename += library_name + filename_extension;
+
+  for (auto it : search_paths) {
+    std::string path = it + "/" + filename;
+    if (is_file_exist(path.c_str())) {
+      return path;
+    }
+  }
+  return "";
+}
+
+
+std::string performance_test::get_library_name(std::string msg_type)
+{
+  const std::string DEFAULT_LIBRARY_NAME = "irobot_interfaces_plugin";
+  std::string namespace_delimiter = "::";
+
+  std::string library_name;
+  //std::string msg_name;
+  size_t pos = msg_type.find(namespace_delimiter);
+  if (pos == std::string::npos) {
+    library_name = DEFAULT_LIBRARY_NAME + "_implementation";
+    //msg_name = msg_type;
+  } else {
+    library_name = msg_type.substr(0, pos) + "_implementation";
+    //msg_name = msg_type.substr(pos + namespace_delimiter.length(), msg_type.length());
+  }
+
+  return library_name;
+}
+
+
+rcutils_shared_library_t performance_test::get_library(std::string msg_type)
+{
+  rcutils_shared_library_t lib = rcutils_get_zero_initialized_shared_library();
+
+  std::string library_name = get_library_name(msg_type);
+
+  std::string library_path = find_library_path(library_name);
+  if (library_path.empty()) {
+    std::cout<<"Error! library path is empty "<<std::endl;
+    return lib;
+  }
+
+  rcutils_ret_t ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
+  if (ret != RCUTILS_RET_OK) {
+    std::cout<<"got exception loading library"<<std::endl;
+    return lib;
+  }
+
+  return lib;
+}

--- a/performances/performance_test_factory/src/load_plugins.cpp
+++ b/performances/performance_test_factory/src/load_plugins.cpp
@@ -7,16 +7,6 @@
  *  You may use, distribute and modify this code under the BSD-3-Clause license.
  */
 
-#include <cstddef>
-#include <cstdio>
-#include <cstring>
-
-#include <list>
-
-#include <fstream>
-#include <iostream>
-#include <sstream>
-
 #include "performance_test_factory/load_plugins.hpp"
 
 using namespace performance_test;

--- a/performances/performance_test_factory/src/load_plugins.cpp
+++ b/performances/performance_test_factory/src/load_plugins.cpp
@@ -21,96 +21,28 @@
 
 using namespace performance_test;
 
-std::string performance_test::get_env_var(const char * env_var)
+static std::string get_library_name(std::string msg_type)
 {
-  char * value = nullptr;
-  value = getenv(env_var);
-  std::string value_str = "";
-  if (value) {
-    value_str = value;
-  }
-  // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
-  return value_str;
-}
-
-std::list<std::string> performance_test::split(const std::string & value, const char delimiter)
-{
-  std::list<std::string> list;
-  std::istringstream ss(value);
-  std::string s;
-  while (std::getline(ss, s, delimiter)) {
-    list.push_back(s);
-  }
-
-  return list;
-}
-
-bool performance_test::is_file_exist(const char * filename)
-{
-  std::ifstream h(filename);
-  return h.good();
-}
-
-std::string performance_test::find_library_path(const std::string & library_name)
-{
-  const char * env_var = "LD_LIBRARY_PATH";
-  char separator = ':';
-  const char * filename_prefix = "lib";
-  const char * filename_extension = ".so";
-
-  std::string search_path = get_env_var(env_var);
-  std::list<std::string> search_paths = split(search_path, separator);
-
-  std::string filename = filename_prefix;
-  filename += library_name + filename_extension;
-
-  for (auto it : search_paths) {
-    std::string path = it + "/" + filename;
-    if (is_file_exist(path.c_str())) {
-      return path;
-    }
-  }
-  return "";
-}
-
-
-std::string performance_test::get_library_name(std::string msg_type)
-{
-  const std::string DEFAULT_LIBRARY_NAME = "irobot_interfaces_plugin";
-  std::string namespace_delimiter = "::";
+  static const std::string DEFAULT_LIBRARY_NAME = "irobot_interfaces_plugin";
+  static const std::string namespace_delimiter = "::";
 
   std::string library_name;
-  //std::string msg_name;
   size_t pos = msg_type.find(namespace_delimiter);
   if (pos == std::string::npos) {
     library_name = DEFAULT_LIBRARY_NAME + "_implementation";
-    //msg_name = msg_type;
   } else {
     library_name = msg_type.substr(0, pos) + "_implementation";
-    //msg_name = msg_type.substr(pos + namespace_delimiter.length(), msg_type.length());
   }
 
   return library_name;
 }
 
-
-rcutils_shared_library_t performance_test::get_library(std::string msg_type)
+std::shared_ptr<rcpputils::SharedLibrary> performance_test::get_library(std::string msg_type)
 {
-  rcutils_shared_library_t lib = rcutils_get_zero_initialized_shared_library();
-
   std::string library_name = get_library_name(msg_type);
 
-  std::string library_path = find_library_path(library_name);
-  if (library_path.empty()) {
-    std::cout<<"Error! library path is empty "<<std::endl;
-    return lib;
-  }
+  const std::string library_path = rcpputils::get_platform_library_name(library_name);
+  auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
 
-  rcutils_ret_t ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
-  if (ret != RCUTILS_RET_OK) {
-    std::cout<<"got exception loading library"<<std::endl;
-    return lib;
-  }
-
-  return lib;
+  return library;
 }


### PR DESCRIPTION
LibPoco has been removed from the ROS dependencies and the functionalities are now part of `rcutils`

https://github.com/ros2/rcutils/issues/216

NOTE: this PR requires master/foxy to work.


Signed-off-by: Soragna, Alberto <alberto.soragna@gmail.com>