### PR TITLE
Add compilation scripts dir as volume

### DIFF
--- a/cross-compiling/cc_workspace.sh
+++ b/cross-compiling/cc_workspace.sh
@@ -30,12 +30,14 @@ WORKSPACE_PATH=$1
 SYSROOT_PATH="$THIS_DIR/sysroots/$TARGET_ARCHITECTURE"
 TOOLCHAIN_PATH="$THIS_DIR/toolchains/generic_linux.cmake"
 TOOLCHAIN_VARIABLES_PATH="$THIS_DIR/toolchains/"$TARGET_ARCHITECTURE".sh"
+COMPILATION_SCRIPTS="$THIS_DIR/compilation_scripts"
 
 docker run -it \
     --volume $WORKSPACE_PATH:/root/ws \
     --volume $SYSROOT_PATH:/root/sysroot \
     --volume $TOOLCHAIN_PATH:/root/ws/toolchainfile.cmake \
     --volume $TOOLCHAIN_VARIABLES_PATH:/root/cc_export.sh \
+    --volume $COMPILATION_SCRIPTS:/root/compilation_scripts \
     -w="/root/ws" \
     ros2_cc_$TARGET_ARCHITECTURE \
     /bin/bash -c 'source /root/.bashrc; \

--- a/cross-compiling/docker_environments/Dockerfile_base
+++ b/cross-compiling/docker_environments/Dockerfile_base
@@ -70,6 +70,3 @@ export PYTHONPATH=/root/sysroot/usr/lib/python3.6/site-packages/:$PYTHONPATH' >>
 # set the AMENT_PREFIX_PATH to the sysroot
 RUN echo '  \n\
 export AMENT_PREFIX_PATH="/root/sysroot/usr;/root/sysroot/usr/bin"' >> $HOME/.bashrc
-
-# copy the compilation scripts into the docker image
-COPY compilation_scripts $HOME/compilation_scripts


### PR DESCRIPTION
It happens quite often the necesity to modify `cross_compile.sh` to change colcon flags, or to avoid deleting the whole build dir when testing some minor code change in a package.
Right now for any change in this script to be reflected in the Docker build environment, the only option is to re-build the Docker image. With this PR any change on the script will be reflected on the Docker container.