### PR TITLE
Create a build directory per architecture

### DIFF
--- a/cross-compiling/cc_workspace.sh
+++ b/cross-compiling/cc_workspace.sh
@@ -37,6 +37,7 @@ docker run -it \
     --volume $TOOLCHAIN_PATH:/root/ws/toolchainfile.cmake \
     --volume $TOOLCHAIN_VARIABLES_PATH:/root/cc_export.sh \
     -w="/root/ws" \
+    -e TARGET_ARCHITECTURE=$TARGET_ARCHITECTURE \
     ros2_cc_$TARGET_ARCHITECTURE \
     /bin/bash -c 'source /root/.bashrc; \
         bash /root/compilation_scripts/cross_compile.sh'

--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -16,6 +16,7 @@ rm -rf build install log
 
 colcon \
     build \
+    --build-base build_$TARGET_ARCHITECTURE \
     --merge-install \
     --cmake-force-configure \
     --cmake-args \


### PR DESCRIPTION
This is useful when compiling the ROS2 SDK
for many architectures with the same sources