### PR TITLE
Optional interactive docker flag

### DIFF
--- a/cross-compiling/cc_workspace.sh
+++ b/cross-compiling/cc_workspace.sh
@@ -31,7 +31,7 @@ SYSROOT_PATH="$THIS_DIR/sysroots/$TARGET_ARCHITECTURE"
 TOOLCHAIN_PATH="$THIS_DIR/toolchains/generic_linux.cmake"
 TOOLCHAIN_VARIABLES_PATH="$THIS_DIR/toolchains/"$TARGET_ARCHITECTURE".sh"
 
-docker run -it \
+docker run \
     --volume $WORKSPACE_PATH:/root/ws \
     --volume $SYSROOT_PATH:/root/sysroot \
     --volume $TOOLCHAIN_PATH:/root/ws/toolchainfile.cmake \

--- a/cross-compiling/cc_workspace.sh
+++ b/cross-compiling/cc_workspace.sh
@@ -31,7 +31,20 @@ SYSROOT_PATH="$THIS_DIR/sysroots/$TARGET_ARCHITECTURE"
 TOOLCHAIN_PATH="$THIS_DIR/toolchains/generic_linux.cmake"
 TOOLCHAIN_VARIABLES_PATH="$THIS_DIR/toolchains/"$TARGET_ARCHITECTURE".sh"
 
+INTERACTIVE_DOCKER="-it"
+
+for i in "$@"
+do
+case $i in
+    --no-it)
+    INTERACTIVE_DOCKER=""
+    shift
+    ;;
+esac
+done
+
 docker run \
+    $INTERACTIVE_DOCKER \
     --volume $WORKSPACE_PATH:/root/ws \
     --volume $SYSROOT_PATH:/root/sysroot \
     --volume $TOOLCHAIN_PATH:/root/ws/toolchainfile.cmake \


### PR DESCRIPTION
Jenkins can't run Docker in an interactive mode, so this PR adds a flag `--no-it` for the script `cc_workspace.sh` to not use the interactive mode when needed