### PR TITLE
Update automatic_cross_compile.sh

### DIFF
--- a/cross-compiling/automatic_cross_compile.sh
+++ b/cross-compiling/automatic_cross_compile.sh
@@ -31,15 +31,14 @@ bash $THIS_DIR/get_ros2_sources.sh --distro=$ROS2_DISTRO --ros2-path=$BASE_DIR/r
 HEAD=$(git ls-remote git://github.com/ros2/ros2 "$ROS2_DISTRO" | cut -c1-7)
 
 # Create install directory for the cross-compilation results
-TARGET_NAME=$(echo "$TARGET" | tr - _)
-RESULTS_DIR=$BASE_DIR/ROS2_SDKs/ros2_"$ROS2_DISTRO"_"$TARGET_NAME"
+RESULTS_DIR=$BASE_DIR/ROS2_SDKs/ros2_"$ROS2_DISTRO"_"$TARGET"
 echo "Create RESULTS_DIR=$RESULTS_DIR"
 sudo rm -rf $RESULTS_DIR
 mkdir -p $RESULTS_DIR
 
 # Save the current packages versions and check if any changes
 ROS2_SRCS_HEADS=$RESULTS_DIR/ros2.repos.by_commit
-ROS2_SRCS_HEADS_PREV_RUN=$BASE_DIR/ros2_srcs_prev_run_"$TARGET_NAME"_"$ROS2_DISTRO".txt
+ROS2_SRCS_HEADS_PREV_RUN=$BASE_DIR/ros2_srcs_prev_run_"$TARGET"_"$ROS2_DISTRO".txt
 
 vcs export --exact $BASE_DIR/ros2_cc_ws/src > $ROS2_SRCS_HEADS
 
@@ -57,7 +56,7 @@ if $CC_CMD; then
   # If the build was successful, copy results to store as artifact
   cp -r $BASE_DIR/ros2_cc_ws/install/* $RESULTS_DIR
   cd $BASE_DIR/ROS2_SDKs/
-  tar -czf ros2_"$ROS2_DISTRO"_"$TARGET_NAME".tar.gz ros2_"$ROS2_DISTRO"_"$TARGET_NAME"
+  tar -czf ros2_"$ROS2_DISTRO"_"$TARGET".tar.gz ros2_"$ROS2_DISTRO"_"$TARGET"
 else
   exit 1
 fi

--- a/cross-compiling/automatic_cross_compile.sh
+++ b/cross-compiling/automatic_cross_compile.sh
@@ -15,7 +15,7 @@ then
 fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-export BASE_DIR="$(dirname "$(pwd)")"
+BASE_DIR="$(dirname "$(pwd)")"
 
 # Prepare cross-compiling environment
 source $THIS_DIR/env.sh $TARGET

--- a/cross-compiling/get_ros2_sources.sh
+++ b/cross-compiling/get_ros2_sources.sh
@@ -1,15 +1,31 @@
 #!/bin/bash
 
+# You can specify a distribution with --distro=<distribution>, otherwise the default one will be used
+DISTRIBUTION="eloquent"
+
+# You can specify a directory to store sources with --ros2-path=<DIR>, otherwise the default one will be used
 ROS2_PATH=~/ros2_cc_ws
 
-# You can specify a distribution, otherwise the default one will be used
-distribution="eloquent"
-if [ -z "$1" ]; then
-  echo "Using default ROS2 $distribution distribution sources"
-else
-  distribution=$1
-  echo "Using ROS2 $distribution distribution sources"
-fi
+for i in "$@"
+do
+case $i in
+    --distro=*)
+    DISTRIBUTION="${i#*=}"
+    shift
+    ;;
+    --ros2-path=*)
+    ROS2_PATH="${i#*=}"
+    shift
+    ;;
+    -h|--help|*)
+    echo "Usage example: bash get_ros2_sources.sh --distro=master --ros2-path=~/ros2_cc_ws"
+    exit 0
+    shift
+    ;;
+esac
+done
+
+echo "Using ROS2 $DISTRIBUTION distribution sources"
 
 if [ -d $ROS2_PATH ]; then
     echo "Error: Directory $ROS2_PATH already exists, remove it to get new sources."
@@ -19,6 +35,6 @@ else
     echo "Downloading ROS2 sources in directory: $ROS2_PATH"
     mkdir -p $ROS2_PATH/src
     cd $ROS2_PATH
-    wget https://raw.githubusercontent.com/ros2/ros2/$distribution/ros2.repos
+    wget https://raw.githubusercontent.com/ros2/ros2/$DISTRIBUTION/ros2.repos
     vcs import src < ros2.repos
 fi


### PR DESCRIPTION
Differences: 
`get_ros2_sources.sh` accepts arguments to where to store the downloaded SDK. Needed because otherwise are stored in `~` , which is a problem in jenkins because it goes out of scope of the workspace in which it's working.
`automatic_cross_compile.sh` reflects this change using the new feature, plus some other changes.