### PR TITLE
Source setup.bash, if exists

### DIFF
--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -14,6 +14,11 @@ fi
 # clear out everything first
 rm -rf build install log
 
+ROS2_SETUP=/root/sysroot/setup.bash
+if [ -f "$ROS2_SETUP" ]; then
+    source /root/sysroot/setup.bash
+fi
+
 colcon \
     build \
     --merge-install \

--- a/cross-compiling/sysroots/x86_64_get_sysroot.sh
+++ b/cross-compiling/sysroots/x86_64_get_sysroot.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-#..nothing to do
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+mkdir $THIS_DIR/x86_64


### PR DESCRIPTION
For x86_64 test package builds, its sysroot contains directly the cross-compiled SDK 
`/root/sysroots/<ROS2 install dir>`
This PR is for sourcing `setup.bash` (that only exist when cross-compiling for x86_64)