### PR TITLE
Fix custom message types from plugin package

### DIFF
--- a/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
+++ b/performances/performance_test_factory/include/performance_test_factory/load_plugins.hpp
@@ -17,6 +17,6 @@
 
 namespace performance_test {
 
-std::shared_ptr<rcpputils::SharedLibrary> get_library(std::string msg_type);
+std::shared_ptr<rcpputils::SharedLibrary> get_library(std::string& msg_type);
 
 }

--- a/performances/performance_test_factory/src/load_plugins.cpp
+++ b/performances/performance_test_factory/src/load_plugins.cpp
@@ -11,7 +11,7 @@
 
 using namespace performance_test;
 
-static std::string get_library_name(std::string msg_type)
+static std::string get_library_name(std::string& msg_type)
 {
   static const std::string DEFAULT_LIBRARY_NAME = "irobot_interfaces_plugin";
   static const std::string namespace_delimiter = "::";
@@ -22,12 +22,13 @@ static std::string get_library_name(std::string msg_type)
     library_name = DEFAULT_LIBRARY_NAME + "_implementation";
   } else {
     library_name = msg_type.substr(0, pos) + "_implementation";
+    msg_type = msg_type.substr(pos + namespace_delimiter.length());
   }
 
   return library_name;
 }
 
-std::shared_ptr<rcpputils::SharedLibrary> performance_test::get_library(std::string msg_type)
+std::shared_ptr<rcpputils::SharedLibrary> performance_test::get_library(std::string& msg_type)
 {
   std::string library_name = get_library_name(msg_type);
 


### PR DESCRIPTION
The message type for custom plugin includes the `my_factory_plugin::` prefix which should be removed once the library is loaded in. 