### PR TITLE
Add exit code to cross_compile.sh

### DIFF
--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -19,19 +19,30 @@ if [ -f "$ROS2_SETUP" ]; then
     source /root/sysroot/setup.bash
 fi
 
-colcon \
-    build \
-    --merge-install \
-    --cmake-force-configure \
-    --cmake-args \
-    -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_PATH \
-    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    -DTHIRDPARTY=ON \
-    -DBUILD_TESTING:BOOL=OFF
-
+COLCON_CMD="colcon \
+                build \
+                --merge-install \
+                --cmake-force-configure \
+                --cmake-args \
+                -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_PATH \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+                -DTHIRDPARTY=ON \
+                -DBUILD_TESTING:BOOL=OFF"
 
 # --merge-install is used to avoid creation of nested install dirs for each package
 
-# Add Read+Write+Execute permissions to workspace, to avoid
+# Create exit code
+EXIT_CODE=0
+
+if ! $COLCON_CMD; then
+  echo "Error: colcon command failed"
+  EXIT_CODE=1
+fi
+
+
+# Set Read+Write+Execute permissions to workspace, to avoid
 # having to be sudo to tar or remove the cross-compiled workspace
 chmod -R a+rwx .
+
+# Exit
+exit $EXIT_CODE


### PR DESCRIPTION
C.I relies on the output exit code of this script to identify if the builds have failed. 

Without this commit, the output exit code of `cross_compile.sh` is always succesful even if the colcon build failed, since the addition of the command
`chmod -R a+rwx .`
which is always succesful