### PR TITLE
Fix compiler warnings

### DIFF
--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -42,7 +42,7 @@ fi
 
 # Set Read+Write+Execute permissions to workspace, to avoid
 # having to be sudo to tar or remove the cross-compiled workspace
-chmod -R a+rwx .
+chmod -R a+rwx $(ls -I src)
 
 # Exit
 exit $EXIT_CODE

--- a/performances/performance_test/src/ros2/tracker.cpp
+++ b/performances/performance_test/src/ros2/tracker.cpp
@@ -69,8 +69,8 @@ void performance_test::Tracker::scan(
         const unsigned int latency_too_late_threshold_us = std::min(_tracking_options.too_late_absolute_us,
                                                                 _tracking_options.too_late_percentage * period_us / 100);
 
-        too_late = static_cast<long>(lat_us) > latency_too_late_threshold_us;
-        late = static_cast<long>(lat_us) > latency_late_threshold_us && !too_late;
+        too_late = lat_us > latency_too_late_threshold_us;
+        late = lat_us > latency_late_threshold_us && !too_late;
 
         if(late) {
             if (elog != nullptr){

--- a/performances/performance_test_factory/src/factory.cpp
+++ b/performances/performance_test_factory/src/factory.cpp
@@ -435,7 +435,7 @@ void performance_test::TemplateFactory::add_periodic_client_from_json(
     std::string service_name = client_json["service_name"];
     std::string srv_type = client_json["srv_type"];
 
-    float period_ms;
+    float period_ms = 0;
 
     if (client_json.find("freq_hz") != client_json.end()) {
         float frequency = client_json["freq_hz"];


### PR DESCRIPTION
1. Fix compiler warnings
2. After crosscompiling, chmod all dirs but `src` directory. Otherwise it's hard to track custom changes on src directories using git, due all files have changed permissions. Anyway, `src` is already owned by the user so no need to change its permissions.