### PR TITLE
Add executor option

### DIFF
--- a/performances/irobot-benchmark/src/irobot-benchmark.cpp
+++ b/performances/irobot-benchmark/src/irobot-benchmark.cpp
@@ -41,6 +41,28 @@ int main(int argc, char** argv)
     std::cout << "Topology file(s): " << std::endl;
     for(const auto& json : json_list) std::cout << json << std::endl;
 
+    // Get the system executor from options
+    performance_test::systemExecutor system_executor;
+    system_executor = static_cast<performance_test::systemExecutor>(options.executor);
+
+    switch (system_executor)
+    {
+        using namespace performance_test;
+
+        case EVENTS_EXECUTOR:
+            std::cout << "System executor: EventsExecutor" << std::endl;
+            break;
+
+        case SINGLE_THREADED_EXECUTOR:
+            std::cout << "System executor: SingleThreadedExecutor" << std::endl;
+            break;
+
+        case STATIC_SINGLE_THREADED_EXECUTOR:
+        default:
+            std::cout << "System executor: StaticSingleThreadedExecutor" << std::endl;
+            break;
+    }
+
     std::cout << "Intra-process-communication: " << (options.ipc ? "on" : "off") << std::endl;
     std::cout << "Parameter services: " << (options.ros_params ? "on" : "off") << std::endl;
     std::cout << "Naming threads: " << (options.name_threads ? "on" : "off") << std::endl;
@@ -48,7 +70,7 @@ int main(int argc, char** argv)
     std::cout << "Sampling resources every " << options.resources_sampling_per_ms << "ms" << std::endl;
     std::cout << "Logging events statistics: " << (options.tracking_options.is_enabled ? "on" : "off") << std::endl;
     std::cout << "Start test" << std::endl;
-    
+
     std::string topology_json;
 
     pid_t pid = getpid();
@@ -89,10 +111,10 @@ int main(int argc, char** argv)
 
     rclcpp::init(argc, argv);
 
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(system_executor);
 
     if (options.tracking_options.is_enabled) {
-        ros2_system.enable_events_logger(events_output_path);    
+        ros2_system.enable_events_logger(events_output_path);
     }
 
     // Load topology from json file

--- a/performances/performance_test/include/cli/options.hpp
+++ b/performances/performance_test/include/cli/options.hpp
@@ -24,6 +24,7 @@ public:
     Options()
     {
         ipc = true;
+        executor = 3;
         ros_params = true;
         name_threads = true;
         duration_sec = 5;
@@ -65,6 +66,8 @@ public:
       ("t,time", "test duration", cxxopts::value<int>(duration_sec)->default_value(std::to_string(duration_sec)),"sec")
       ("s, sampling", "resources sampling period",
         cxxopts::value<int>(resources_sampling_per_ms)->default_value(std::to_string(resources_sampling_per_ms)),"msec")
+      ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
       ("tracking", "compute and logs detailed statistics and events",
         cxxopts::value<std::string>(tracking_enabled_option)->default_value(tracking_options.is_enabled ? "on" : "off"),"on/off")
       ("late-percentage", "a msg with greater latency than this percentage of the msg publishing period is considered late",
@@ -111,6 +114,7 @@ public:
     bool ipc;
     bool ros_params;
     bool name_threads;
+    int executor;
     int duration_sec;
     int resources_sampling_per_ms;
     std::vector<std::string> topology_json_list;

--- a/performances/performance_test/include/performance_test/ros2/system.hpp
+++ b/performances/performance_test/include/performance_test/ros2/system.hpp
@@ -19,16 +19,22 @@ namespace performance_test {
 
 struct NamedExecutor
 {
-    rclcpp::executors::StaticSingleThreadedExecutor::SharedPtr executor;
+    std::shared_ptr<rclcpp::Executor> executor;
     std::string name;
 };
 
+typedef enum
+{
+  EVENTS_EXECUTOR = 1,
+  SINGLE_THREADED_EXECUTOR = 2,
+  STATIC_SINGLE_THREADED_EXECUTOR = 3
+} systemExecutor;
 
 class System
 {
 public:
 
-  System() = default;
+  System(systemExecutor executor);
 
   void add_node(std::vector<std::shared_ptr<Node>> nodes);
 
@@ -68,8 +74,9 @@ private:
 
   std::map<int, NamedExecutor> _executors_map;
 
-
   std::shared_ptr<EventsLogger> _events_logger;
+
+  systemExecutor _system_executor;
 
   // the following values are used for comparing different plots using the python scripts
   bool _got_system_info;

--- a/performances/performance_test/src/ros2/system.cpp
+++ b/performances/performance_test/src/ros2/system.cpp
@@ -15,6 +15,12 @@
 #include "performance_test/ros2/names_utilities.hpp"
 
 
+performance_test::System::System(systemExecutor executor)
+{
+    _system_executor = executor;
+}
+
+
 void performance_test::System::enable_events_logger(std::string events_logger_path)
 {
     _events_logger = std::make_shared<EventsLogger>(events_logger_path);
@@ -43,7 +49,23 @@ void performance_test::System::add_node(std::shared_ptr<Node> node)
         ex.name = ex.name + "_" + node->get_name();
     } else {
         auto ex = NamedExecutor();
-        ex.executor = std::make_shared<rclcpp::executors::StaticSingleThreadedExecutor>();
+
+        switch (_system_executor)
+        {
+            case EVENTS_EXECUTOR:
+                ex.executor = std::make_shared<rclcpp::executors::EventsExecutor>();
+                break;
+
+            case SINGLE_THREADED_EXECUTOR:
+                ex.executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+                break;
+
+            case STATIC_SINGLE_THREADED_EXECUTOR:
+            default:
+                ex.executor = std::make_shared<rclcpp::executors::StaticSingleThreadedExecutor>();
+                break;
+        }
+
         ex.executor->add_node(node);
         ex.name = node->get_name();
 

--- a/performances/performance_test/test/test_system.cpp
+++ b/performances/performance_test/test/test_system.cpp
@@ -31,12 +31,14 @@ TEST_F(TestSystem, SystemAddNodesTest)
     auto node_3 = std::make_shared<performance_test::Node>("node_3");
     std::vector<std::shared_ptr<performance_test::Node>> nodes_vec = {node_2, node_3};
 
-    performance_test::System separate_threads_system;
+    performance_test::systemExecutor system_executor;
+    system_executor = performance_test::STATIC_SINGLE_THREADED_EXECUTOR;
+    performance_test::System separate_threads_system(system_executor);
 
     separate_threads_system.add_node(node_1);
     separate_threads_system.add_node(nodes_vec);
 
-    performance_test::System single_executor_system;
+    performance_test::System single_executor_system(system_executor);
 
     single_executor_system.add_node(node_1);
     single_executor_system.add_node(nodes_vec);
@@ -49,7 +51,9 @@ TEST_F(TestSystem, SystemPubSubTest)
     auto topic = performance_test::Topic<performance_test_msgs::msg::Sample>("my_topic");
 
     int duration_sec = 1;
-    performance_test::System ros2_system;
+    performance_test::systemExecutor system_executor;
+    system_executor = performance_test::STATIC_SINGLE_THREADED_EXECUTOR;
+    performance_test::System ros2_system(system_executor);
 
     // Create 1 pulisher node and 1 subscriber node
     auto pub_node = std::make_shared<performance_test::Node>("pub_node");
@@ -75,7 +79,9 @@ TEST_F(TestSystem, SystemClientServerTest)
     auto service = performance_test::Topic<performance_test_msgs::srv::Sample>("my_service");
 
     int duration_sec = 2;
-    performance_test::System ros2_system;
+    performance_test::systemExecutor system_executor;
+    system_executor = performance_test::STATIC_SINGLE_THREADED_EXECUTOR;
+    performance_test::System ros2_system(system_executor);
 
     // Create 1 client node and 1 server node
     auto client_node = std::make_shared<performance_test::Node>("client_node");
@@ -102,7 +108,9 @@ TEST_F(TestSystem, SystemDifferentQoSTest)
     auto topic = performance_test::Topic<performance_test_msgs::msg::Sample>("my_topic");
 
     int duration_sec = 1;
-    performance_test::System ros2_system;
+    performance_test::systemExecutor system_executor;
+    system_executor = performance_test::STATIC_SINGLE_THREADED_EXECUTOR;
+    performance_test::System ros2_system(system_executor);
     rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
 
     // Create 1 pulisher node and 1 subscriber node

--- a/performances/performance_test_factory/examples/client_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/client_nodes_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_clients = 2;
     int n_services = 1;
     std::string msg_type = "stamped10b";
@@ -45,6 +46,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("client_nodes_main", "Run some ROS2 client nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("c,clients", "Number of client nodes",
         cxxopts::value<int>(n_clients)->default_value(std::to_string(n_clients)))
     ("s,services", "Number of service ndoes",
@@ -96,7 +99,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> client_nodes =

--- a/performances/performance_test_factory/examples/json_system_main.cpp
+++ b/performances/performance_test_factory/examples/json_system_main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv)
     std::string this_file_path = __FILE__;
     std::string this_dir_path = this_file_path.substr(0, this_file_path.rfind("/"));
     std::string json_path = this_dir_path + std::string("/simple_architecture.json");
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int use_ipc = 1;
     int experiment_duration = 5;
     int resources_sampling_per_ms = 500;
@@ -38,6 +39,8 @@ int main(int argc, char** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("json_system_main", "Create a ROS2 system at runtime as defined by a JSON file");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("j, json", "path to the json file to load",
         cxxopts::value<std::string>(json_path)->default_value(json_path))
     ("use_ipc", "Activate IntraProcessCommunication (0 or 1 accepted arguments)",
@@ -81,7 +84,7 @@ int main(int argc, char** argv)
     rclcpp::init(argc, argv);
 
     // Architecture
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_output_path);
 
     performance_test::TemplateFactory factory(use_ipc);

--- a/performances/performance_test_factory/examples/publisher_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/publisher_nodes_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_subscribers = 2;
     int n_publishers = 1;
     std::string msg_type = "stamped10b";
@@ -46,6 +47,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("publisher_nodes_main", "Run some ROS2 publisher nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("s,subs", "Number of subscriber nodes",
         cxxopts::value<int>(n_subscribers)->default_value(std::to_string(n_subscribers)))
     ("p,pubs", "Number of publisher ndoes",
@@ -99,7 +102,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> pub_nodes =

--- a/performances/performance_test_factory/examples/server_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/server_nodes_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_clients = 2;
     int n_services = 1;
     std::string msg_type = "stamped10b";
@@ -45,6 +46,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("client_nodes_main", "Run some ROS2 client nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("c,clients", "Number of client nodes",
         cxxopts::value<int>(n_clients)->default_value(std::to_string(n_clients)))
     ("s,services", "Number of service ndoes",
@@ -96,7 +99,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> server_nodes =

--- a/performances/performance_test_factory/examples/simple_client_service_main.cpp
+++ b/performances/performance_test_factory/examples/simple_client_service_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_clients = 2;
     int n_services = 1;
     std::string msg_type = "stamped10b";
@@ -45,6 +46,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("client_nodes_main", "Run some ROS2 client nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("c,clients", "Number of client nodes",
         cxxopts::value<int>(n_clients)->default_value(std::to_string(n_clients)))
     ("s,services", "Number of service ndoes",
@@ -96,7 +99,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> server_nodes =

--- a/performances/performance_test_factory/examples/simple_pub_sub_main.cpp
+++ b/performances/performance_test_factory/examples/simple_pub_sub_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_subscribers = 2;
     int n_publishers = 1;
     std::string msg_type = "stamped10b";
@@ -46,6 +47,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("publisher_nodes_main", "Run some ROS2 publisher nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("s,subs", "Number of subscriber nodes",
         cxxopts::value<int>(n_subscribers)->default_value(std::to_string(n_subscribers)))
     ("p,pubs", "Number of publisher ndoes",
@@ -99,7 +102,7 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> pub_nodes =

--- a/performances/performance_test_factory/examples/subscriber_nodes_main.cpp
+++ b/performances/performance_test_factory/examples/subscriber_nodes_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
      */
 
     // experiment default values
+    int executor = 3; // ID corresponding to the StaticSingleThreadedExecutor
     int n_subscribers = 2;
     int n_publishers = 1;
     std::string msg_type = "stamped10b";
@@ -46,6 +47,8 @@ int main(int argc, char ** argv)
     // parse the command line arguments and eventually overwrite the default values
     cxxopts::Options options("publisher_nodes_main", "Run some ROS2 publisher nodes");
     options.add_options()
+    ("x, executor", "the system executor:\n\t\t\t\t1:EventsExecutor. 2:SingleThreadedExecutor. 3:StaticSingleThreadedExecutor",
+        cxxopts::value<int>(executor)->default_value(std::to_string(executor)),"<1/2/3>")
     ("s,subs", "Number of subscriber nodes",
         cxxopts::value<int>(n_subscribers)->default_value(std::to_string(n_subscribers)))
     ("p,pubs", "Number of publisher ndoes",
@@ -99,7 +102,8 @@ int main(int argc, char ** argv)
     rclcpp::init(argc, argv);
 
     performance_test::TemplateFactory factory(use_ipc, use_ros_params, verbose, ros_namespace);
-    performance_test::System ros2_system;
+
+    performance_test::System ros2_system(static_cast<performance_test::systemExecutor>(executor));
     ros2_system.enable_events_logger(events_file_path);
 
     std::vector<std::shared_ptr<performance_test::Node>> sub_nodes =


### PR DESCRIPTION
```
ROS2 performance benchmark
Usage:
  ./irobot-benchmark [OPTION...] FILE [FILE...]

  -h, --help                    print help
  -x, --executor <1/2/3>        the system executor:
				1:EventsExecutor.
                                2:SingleThreadedExecutor.
                                3:StaticSingleThreadedExecutor (default: 3)
```
Example using EventsExecutor :
```
./irobot-benchmark topology/sierra_nevada.json -x 1
```
Shouldn't be merged until the EventsExecutor PR https://github.com/ros2/rclcpp/pull/1416 gets in.