### PR TITLE
White Mountain: Use one executor per node

### DIFF
--- a/performances/irobot-benchmark/topology/white_mountain.json
+++ b/performances/irobot-benchmark/topology/white_mountain.json
@@ -4,28 +4,32 @@
         "node_name": "cordoba",
         "publishers": [
               {"topic_name": "amazon", "msg_type": "stamped9_float32", "period_ms": 10}
-            ]
+            ],
+        "executor_id":1
       },
 
       {
         "node_name": "freeport",
         "publishers": [
               {"topic_name": "ganges", "msg_type": "stamped4_int32", "period_ms": 10}
-            ]
+            ],
+        "executor_id":2
       },
 
       {
         "node_name": "medellin",
         "publishers": [
               {"topic_name": "nile", "msg_type": "stamped4_int32", "period_ms": 10}
-            ]
+            ],
+        "executor_id":3
       },
 
       {
         "node_name": "portsmouth",
         "publishers": [
               {"topic_name": "danube", "msg_type": "stamped_int64", "period_ms": 10}
-            ]
+            ],
+        "executor_id":4
       },
 
       {
@@ -35,7 +39,8 @@
           ],
         "publishers": [
             {"topic_name": "tigris", "msg_type": "stamped4_float32", "period_ms": 10}
-          ]
+          ],
+        "executor_id":5
       },
 
       {
@@ -48,14 +53,16 @@
           ],
         "publishers": [
             {"topic_name": "parana", "msg_type": "stamped3_float32", "period_ms": 10}
-          ]
+          ],
+        "executor_id":6
       },
 
       {
         "node_name": "delhi",
         "publishers": [
               {"topic_name": "columbia", "msg_type": "stamped600kb", "freq_hz": 15}
-            ]
+            ],
+        "executor_id":7
       },
 
       {
@@ -65,7 +72,8 @@
           ],
         "publishers": [
             {"topic_name": "colorado", "msg_type": "stamped4_int32", "period_ms": 200}
-          ]
+          ],
+        "executor_id":8
       },
 
       {
@@ -77,7 +85,8 @@
         "publishers": [
             {"topic_name": "salween", "msg_type": "stamped12_float32", "period_ms": 100},
             {"topic_name": "godavari", "msg_type": "stamped_vector", "msg_size": 5000, "period_ms": 200}
-          ]
+          ],
+        "executor_id":9
       },
 
       {
@@ -88,21 +97,24 @@
           ],
         "publishers": [
             {"topic_name": "loire", "msg_type": "stamped_vector", "msg_size": 1000, "period_ms": 200}
-          ]
+          ],
+        "executor_id":10
       },
 
       {
         "node_name": "kingston",
         "publishers": [
               {"topic_name": "yamuna", "msg_type": "stamped4_int32", "period_ms": 100}
-            ]
+            ],
+        "executor_id":11
       },
 
       {
         "node_name": "hebron",
         "publishers": [
               {"topic_name": "chenab", "msg_type": "stamped1kb", "period_ms": 25}
-            ]
+            ],
+        "executor_id":12
       },
 
       {
@@ -119,7 +131,8 @@
             {"topic_name": "missouri", "msg_type": "stamped_vector", "msg_size": 10000, "period_ms": 100},
             {"topic_name": "tagus", "msg_type": "stamped_vector", "msg_size": 50000, "period_ms": 100},
             {"topic_name": "brazos", "msg_type": "stamped_vector", "msg_size": 25000, "period_ms": 100}
-          ]
+          ],
+        "executor_id":13
       },
 
       {
@@ -138,7 +151,8 @@
         "publishers": [
             {"topic_name": "mekong", "msg_type": "stamped_vector", "msg_size": 100, "period_ms": 500},
             {"topic_name": "congo", "msg_type": "stamped4_int32", "period_ms": 100}
-          ]
+          ],
+        "executor_id":14
       },
 
       {
@@ -148,7 +162,8 @@
           ],
         "publishers": [
             {"topic_name": "lena", "msg_type": "stamped_vector", "msg_size": 50, "period_ms": 100}
-          ]
+          ],
+        "executor_id":15
       },
 
       {
@@ -158,7 +173,8 @@
           ],
         "publishers": [
             {"topic_name": "ohio", "msg_type": "stamped100b", "period_ms": 200}
-          ]
+          ],
+        "executor_id":16
       },
 
       {
@@ -169,7 +185,8 @@
           ],
         "publishers": [
             {"topic_name": "volga", "msg_type": "stamped_int64", "period_ms": 500}
-          ]
+          ],
+        "executor_id":17
       },
 
       {
@@ -179,7 +196,8 @@
           ],
         "publishers": [
             {"topic_name": "murray", "msg_type": "stamped_vector", "msg_size": 100, "period_ms": 500}
-          ]
+          ],
+        "executor_id":18
       },
 
       {
@@ -192,14 +210,16 @@
           ],
         "publishers": [
             {"topic_name": "arkansas", "msg_type": "stamped4_int32", "period_ms": 100}
-          ]
+          ],
+        "executor_id":19
       },
 
       {
         "node_name": "arequipa",
         "subscribers":[
             {"topic_name":"arkansas", "msg_type":"stamped4_int32"}
-          ]
+          ],
+        "executor_id":20
       }
     ]
 }


### PR DESCRIPTION
The current default is that all nodes are in the same executor, however we have seen that there are better performances with every node in a separate executor. The default is changed to reflect that.

The system supports json files where the executor is specified only for some nodes. All the other nodes without an explicit executor ID end up in the same executor.