### PR TITLE
split x86_64 and cross-compilation jobs

### DIFF
--- a/cross-compiling/cc_workspace.sh
+++ b/cross-compiling/cc_workspace.sh
@@ -25,20 +25,50 @@ if [ -z "$TARGET_ARCHITECTURE" ]; then
 fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-
 WORKSPACE_PATH=$1
-SYSROOT_PATH="$THIS_DIR/sysroots/$TARGET_ARCHITECTURE"
-TOOLCHAIN_PATH="$THIS_DIR/toolchains/generic_linux.cmake"
-TOOLCHAIN_VARIABLES_PATH="$THIS_DIR/toolchains/"$TARGET_ARCHITECTURE".sh"
 
-INTERACTIVE_DOCKER="-it"
-COMMAND=(/bin/bash -c "source /root/.bashrc && bash /root/compilation_scripts/cross_compile.sh")
+# Some steps are not required for x86_64 compilation
+if [ "$TARGET_ARCHITECTURE" != "x86_64" ]; then
+
+    SYSROOT_PATH="$THIS_DIR/sysroots/$TARGET_ARCHITECTURE"
+    TOOLCHAIN_TEMPLATE_PATH="$THIS_DIR/toolchains/generic_linux.cmake"
+    TOOLCHAIN_ARCH_SPECIFIC_PATH="$THIS_DIR/toolchains/"$TARGET_ARCHITECTURE".sh"
+
+    if [ ! -f "$TOOLCHAIN_TEMPLATE_PATH" ]; then
+        echo "Generic toolchain not found. Looking for"
+        echo "$TOOLCHAIN_TEMPLATE_PATH"
+        exit 1
+    fi
+
+    if [ ! -f "$TOOLCHAIN_ARCH_SPECIFIC_PATH" ]; then
+        echo "Toolchain settings for target architecture $TARGET_ARCHITECTURE not found. Looking for"
+        echo "$TOOLCHAIN_ARCH_SPECIFIC_PATH"
+        exit 1
+    fi
+
+    if [ ! -d "$SYSROOT_PATH" ]; then
+        echo "Sysroot for target architecture $TARGET_ARCHITECTURE not found. Looking for"
+        echo "$SYSROOT_PATH"
+        echo "Please run first get_sysroot.sh"
+        exit 1
+    fi
+
+    SYSROOT_VOLUME_ARG="--volume $SYSROOT_PATH:/root/sysroot"
+    TOOLCHAIN_VOLUME_ARG="--volume $TOOLCHAIN_TEMPLATE_PATH:/root/ws/toolchainfile.cmake"
+    TOOLCHAIN_ARCH_SPECIFIC_VOLUME_ARG="--volume $TOOLCHAIN_ARCH_SPECIFIC_PATH:/root/cc_export.sh"
+    COMPILATION_SCRIPT=/root/compilation_scripts/cross_compile.sh
+else
+    COMPILATION_SCRIPT=/root/compilation_scripts/compile.sh
+fi
+
+INTERACTIVE_DOCKER_ARG="-it"
+COMMAND=(/bin/bash -c "source /root/.bashrc && bash $COMPILATION_SCRIPT")
 
 for i in "$@"
 do
 case $i in
     --no-it)
-    INTERACTIVE_DOCKER=""
+    INTERACTIVE_DOCKER_ARG=""
     shift
     ;;
     --debug)
@@ -48,19 +78,15 @@ case $i in
 esac
 done
 
-if [ ! -d "$SYSROOT_PATH" ]; then
-    echo "Sysroot for target architecture $TARGET_ARCHITECTURE not found. Looking for"
-    echo "$SYSROOT_PATH"
-    echo "Please run first get_sysroot.sh"
-    exit 1
-fi
+CONTAINER_WORKSPACE_PATH=/root/ws
+WORKSPACE_VOLUME_ARG="--volume $WORKSPACE_PATH:$CONTAINER_WORKSPACE_PATH"
 
 docker run \
-    $INTERACTIVE_DOCKER \
-    --volume $WORKSPACE_PATH:/root/ws \
-    --volume $SYSROOT_PATH:/root/sysroot \
-    --volume $TOOLCHAIN_PATH:/root/ws/toolchainfile.cmake \
-    --volume $TOOLCHAIN_VARIABLES_PATH:/root/cc_export.sh \
-    -w="/root/ws" \
+    $INTERACTIVE_DOCKER_ARG \
+    $WORKSPACE_VOLUME_ARG \
+    $SYSROOT_VOLUME_ARG \
+    $TOOLCHAIN_VOLUME_ARG \
+    $TOOLCHAIN_ARCH_SPECIFIC_VOLUME_ARG \
+    -w="$CONTAINER_WORKSPACE_PATH" \
     ros2_cc_$TARGET_ARCHITECTURE \
     "${COMMAND[@]}"

--- a/cross-compiling/compilation_scripts/cross_compile.sh
+++ b/cross-compiling/compilation_scripts/cross_compile.sh
@@ -16,7 +16,12 @@ rm -rf build install log
 
 ROS2_SETUP=/root/sysroot/setup.bash
 if [ -f "$ROS2_SETUP" ]; then
-    source /root/sysroot/setup.bash
+    source $ROS2_SETUP
+fi
+
+ARCH_SPECIFIC_TOOLCHAIN=/root/cc_export.sh
+if [ -f "$ARCH_SPECIFIC_TOOLCHAIN" ]; then
+    source $ARCH_SPECIFIC_TOOLCHAIN
 fi
 
 COLCON_CMD="colcon \

--- a/cross-compiling/docker_environments/Dockerfile_base
+++ b/cross-compiling/docker_environments/Dockerfile_base
@@ -55,10 +55,6 @@ RUN pip3 install -U \
 
 ###### ADDITIONAL SCRIPTS AND ENVIRONMENT VARIABLES
 
-# export architecture specific toolchain variables
-RUN echo ' \n\
-source /root/cc_export.sh' >> $HOME/.bashrc
-
 # TODO: investigate why this line is needed. It's the path where ament packages are installed.
 # These packages are required when cross-compiling additional packages once the sysroot already contains the ROS2 SDK
 # add the sysroot python modules to PYTHONPATH

--- a/cross-compiling/docker_environments/Dockerfile_x86_64
+++ b/cross-compiling/docker_environments/Dockerfile_x86_64
@@ -1,17 +1,11 @@
 
-FROM ros2_cc_irobot
+FROM ros2_cc_base
 LABEL maintainer="Alberto Soragna asoragna at irobot dot com"
 
 # install Fast-RTPS dependencies
 RUN apt-get install --no-install-recommends -y \
-  libasio-dev
-
-# Installing libtinyxml2 version 2.2.0
-# From apt-get install we'd get the version 6.0
-RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml2/libtinyxml2-2v5_2.2.0-1.1ubuntu1_amd64.deb
-RUN dpkg -i libtinyxml2-2v5_2.2.0-1.1ubuntu1_amd64.deb
-RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml2/libtinyxml2-dev_2.2.0-1.1ubuntu1_amd64.deb
-RUN dpkg -i libtinyxml2-dev_2.2.0-1.1ubuntu1_amd64.deb
+  libasio-dev \
+  libtinyxml2-dev
 
 RUN pip3 install \
   numpy

--- a/cross-compiling/env.sh
+++ b/cross-compiling/env.sh
@@ -10,7 +10,7 @@ TARGET_NAME=$1
 
 #Check target architecture toolchain script
 TOOLCHAIN_SCRIPT=$THIS_DIR/toolchains/$TARGET_NAME.sh
-if [ ! -f "$TOOLCHAIN_SCRIPT" ]; then
+if [ ! -f "$TOOLCHAIN_SCRIPT" ] && [ "$TARGET_NAME" != "x86_64" ]; then
     echo "ERROR: File $TOOLCHAIN_SCRIPT does not exist!!!."
     return 1
 fi
@@ -18,6 +18,8 @@ fi
 export TARGET_ARCHITECTURE=$TARGET_NAME
 echo "Environment sourced correctly!"
 echo "TARGET_ARCHITECTURE env variable set to '$TARGET_NAME'"
-echo "These paths will be used as target for the cross-compilation"
-echo "Path to sysroot: $THIS_DIR/sysroots/$TARGET_NAME"
-echo "Path to target specific toolchain: $THIS_DIR/toolchains/$TARGET_NAME.sh"
+if [ "$TARGET_NAME" != "x86_64" ]; then
+    echo "These paths will be used as target for the cross-compilation"
+    echo "Path to sysroot: $THIS_DIR/sysroots/$TARGET_NAME"
+    echo "Path to target specific toolchain: $TOOLCHAIN_SCRIPT"
+fi

--- a/cross-compiling/toolchains/x86_64.sh
+++ b/cross-compiling/toolchains/x86_64.sh
@@ -1,3 +1,0 @@
-export TARGET_ARCH=x86_64
-
-export SYSROOT=/


### PR DESCRIPTION
This fixes a problem where during x86_64 build cmake was setting the CMAKE_CROSSCOMPILATION variable to true, due to the presence of toolchain, etc

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>