### PR TITLE
add publisher stats

### DIFF
--- a/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
@@ -295,7 +295,10 @@ private:
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
-    
+
+          tracker.set_frequency(msg->header.frequency);
+          tracker.set_size(msg->header.size);
+
           auto start_time = std::chrono::high_resolution_clock::now();
 
           pub->publish(*msg);
@@ -318,6 +321,9 @@ private:
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
+
+          tracker.set_frequency(msg->header.frequency);
+          tracker.set_size(msg->header.size);
 
           auto start_time = std::chrono::high_resolution_clock::now();
 

--- a/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
@@ -128,7 +128,8 @@ public:
 
     pub->on_activate();
 
-    _pubs.insert({ topic.name, {pub, 0} });
+    auto tracking_options = Tracker::TrackingOptions();
+    _pubs.insert({ topic.name, { pub, Tracker(this->get_name(), topic.name, tracking_options) } });
 
     RCLCPP_INFO(this->get_logger(),"Publisher to %s created", topic.name.c_str());
   }
@@ -244,6 +245,17 @@ public:
     return trackers;
   }
 
+  std::shared_ptr<Trackers> pub_trackers()
+  {
+    auto trackers = std::make_shared<Trackers>();
+
+    for(const auto& pub : _pubs)
+    {
+      trackers->push_back({pub.first, pub.second.second});
+    }
+
+    return trackers;
+  }
 
   void set_events_logger(std::shared_ptr<EventsLogger> ev)
   {
@@ -265,8 +277,10 @@ private:
     // Get publisher and tracking count from map
     auto& pub_pair = _pubs.at(name);
     auto pub = std::static_pointer_cast<rclcpp_lifecycle::LifecyclePublisher<Msg>>(pub_pair.first);
-    auto& tracking_number = pub_pair.second;
+    auto& tracker = pub_pair.second;
 
+    auto tracking_number = tracker.get_and_update_tracking_number();
+    unsigned long pub_time_us = 0;
     switch (msg_pass_by)
     {
       case PASS_BY_SHARED_PTR:
@@ -281,8 +295,14 @@ private:
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
+    
+          auto start_time = std::chrono::high_resolution_clock::now();
 
           pub->publish(*msg);
+
+          auto end_time = std::chrono::high_resolution_clock::now();
+          pub_time_us = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count();
+    
           break;
       }
 
@@ -299,15 +319,21 @@ private:
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
 
+          auto start_time = std::chrono::high_resolution_clock::now();
+
           pub->publish(std::move(msg));
+
+          auto end_time = std::chrono::high_resolution_clock::now();
+          pub_time_us = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count();
+
           break;
       }
 
     }
 
-    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d", name.c_str(), tracking_number);
+    tracker.add_sample(pub_time_us);
 
-    tracking_number++;
+    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d", name.c_str(), tracking_number);
   }
 
   template <typename DataT>
@@ -458,7 +484,7 @@ private:
 
   // A topic-name indexed map to store the publisher pointers with their
   // trackers.
-  std::map<std::string, std::pair<std::shared_ptr<void>, Tracker::TrackingNumber>> _pubs;
+  std::map<std::string, std::pair<std::shared_ptr<void>, Tracker>> _pubs;
 
   // A topic-name indexed map to store the subscriber pointers with their
   // trackers.

--- a/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
@@ -339,7 +339,7 @@ private:
 
     tracker.add_sample(pub_time_us);
 
-    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d", name.c_str(), tracking_number);
+    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d took %lu us", name.c_str(), tracking_number, pub_time_us);
   }
 
   template <typename DataT>

--- a/performances/performance_test/include/performance_test/ros2/node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/node.hpp
@@ -337,7 +337,7 @@ private:
 
     tracker.add_sample(pub_time_us);
 
-    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d", name.c_str(), tracking_number);
+    RCLCPP_DEBUG(this->get_logger(), "Publishing to %s msg number %d took %lu us", name.c_str(), tracking_number, pub_time_us);
   }
 
   template <typename DataT>

--- a/performances/performance_test/include/performance_test/ros2/node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/node.hpp
@@ -294,6 +294,9 @@ private:
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
     
+          tracker.set_frequency(msg->header.frequency);
+          tracker.set_size(msg->header.size);
+
           auto start_time = std::chrono::high_resolution_clock::now();
 
           pub->publish(*msg);
@@ -316,6 +319,9 @@ private:
           msg->header.tracking_number = tracking_number;
           //attach the timestamp as last operation before publishing
           msg->header.stamp = this->now();
+
+          tracker.set_frequency(msg->header.frequency);
+          tracker.set_size(msg->header.size);
 
           auto start_time = std::chrono::high_resolution_clock::now();
 

--- a/performances/performance_test/include/performance_test/ros2/tracker.hpp
+++ b/performances/performance_test/include/performance_test/ros2/tracker.hpp
@@ -47,6 +47,10 @@ public:
     const rclcpp::Time& now,
     std::shared_ptr<EventsLogger> elog = nullptr);
 
+  void add_sample(unsigned long latency_sample);
+
+  TrackingNumber get_and_update_tracking_number();
+
   unsigned long int lost() const { return _lost_messages; }
 
   unsigned long int late() const { return _late_messages; }

--- a/performances/performance_test/include/performance_test/ros2/tracker.hpp
+++ b/performances/performance_test/include/performance_test/ros2/tracker.hpp
@@ -67,6 +67,8 @@ public:
 
   void set_frequency(float f) { _frequency = f; }
 
+  void set_size(size_t s) { _size = s; }
+
   unsigned long int last() const { return _last_latency; }
 
 private:

--- a/performances/performance_test/src/ros2/tracker.cpp
+++ b/performances/performance_test/src/ros2/tracker.cpp
@@ -110,8 +110,20 @@ void performance_test::Tracker::scan(
     if(!too_late) {
         // Compute statistics with new sample. Don't add to this the msgs
         // that arrived too late.
-        _stat.add_sample(lat_us);
+        this->add_sample(lat_us);
     }
 
     _received_messages++;
+}
+
+void performance_test::Tracker::add_sample(unsigned long latency_sample)
+{
+    _stat.add_sample(latency_sample);
+}
+
+performance_test::Tracker::TrackingNumber performance_test::Tracker::get_and_update_tracking_number()
+{
+    TrackingNumber old_number = _tracking_number_count;
+    _tracking_number_count++;
+    return old_number;
 }

--- a/performances/performance_test/src/ros2/tracker.cpp
+++ b/performances/performance_test/src/ros2/tracker.cpp
@@ -19,8 +19,8 @@ void performance_test::Tracker::scan(
 {
     // If this is first message received store some info about it
     if (stat().n() == 0) {
-        _size = header.size;
-        _frequency = header.frequency;
+        this->set_size(header.size);
+        this->set_frequency(header.frequency);
     }
 
     // Compute latency

--- a/performances/performance_test/test/test_lifecycle_node.cpp
+++ b/performances/performance_test/test/test_lifecycle_node.cpp
@@ -54,5 +54,5 @@ TEST_F(TestNode, NodeAddItemsTest)
   node->add_server(service);
   node->add_periodic_client(service, std::chrono::milliseconds(10));
 
-  ASSERT_EQ((size_t)2, node->all_trackers()->size());
+  ASSERT_EQ((size_t)3, node->all_trackers()->size());
 }


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>


This PR adds separate statistics for publishers.
These monitor the time it takes for the `publisher->publish` function to return.

The current output is something like
```
Publishers stats:
node           topic          size[b]   received[#]    late[#]   too_late[#]    lost[#]   mean[us]  sd[us]    min[us]   max[us]   freq[hz]  duration[s]
prod_a         topic_a        0         0              0         0              0         164       29        154       645       0         5         
prod_b         topic_b        0         0              0         0              0         140       14        119       186       0         5         
```

Most of the fields are empty, but the interesting ones are there