### PR TITLE
Explicit dependency on ament_cmake_copyright

### DIFF
--- a/performance_test_factory/package.xml
+++ b/performance_test_factory/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>irobot_interfaces_plugin</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>


### PR DESCRIPTION
Due to being used in testing here https://github.com/irobot-ros/ros2-performance/blob/39d3c9aae97e69b6cb68fd75d7905b0d91adaa73/performance_test_factory/CMakeLists.txt#L71