### PR TITLE
Add to the generate_factory_plugin cmake back-support for galactic

### DIFF
--- a/performance_test_plugin_cmake/cmake/generate_factory_plugin.cmake
+++ b/performance_test_plugin_cmake/cmake/generate_factory_plugin.cmake
@@ -32,7 +32,13 @@ function(generate_factory_plugin argMSGS argSRVS)
     ${CUSTOM_TARGET_PATH}
   )
   ament_target_dependencies(${LIBRARY_NAME} ${LIBRARY_DEPENDENCIES})
-  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+  # First try >= Humble, fall back to <= Galactic
+  if(COMMAND rosidl_get_typesupport_target)
+    rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  else()
+    rosidl_target_interfaces(${LIBRARY_NAME} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  endif()
   target_link_libraries(${LIBRARY_NAME} ${cpp_typesupport_target})
 
   install(TARGETS


### PR DESCRIPTION
#### Overview
- Galactic support is still required in certain cases and this PR adds back in that tiny bit of support
- Leverage the cmake `if(COMMAND ...)` to check which macro is available thus not relying on the environment (`ROS_DISTRO`, etc)

#### How was this tested?
- Launch the [OSRF-Humble docker container](https://docs.ros.org/en/humble/How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers.html#run-two-nodes-in-a-single-docker-container), clean build and run this package
- Launch the [OSRF-Galactic docker container](https://docs.ros.org/en/galactic/How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers.html#run-two-nodes-in-a-single-docker-container), clean build and run this package

#### Humble for example
```bash
root@<some-machine>:~/ros/performance_ws# colcon build
Starting >>> performance_test_msgs
Finished <<< performance_test_msgs [2.71s]                     
Starting >>> performance_metrics
Finished <<< performance_metrics [3.89s]                     
Starting >>> performance_test
Finished <<< performance_test [9.07s]                      
Starting >>> performance_test_plugin_cmake
Finished <<< performance_test_plugin_cmake [0.43s]                 
Starting >>> irobot_interfaces_plugin
[Processing: irobot_interfaces_plugin]                             
Finished <<< irobot_interfaces_plugin [46.6s]                           
Starting >>> performance_test_factory
Finished <<< performance_test_factory [7.25s]                           
Starting >>> composition_benchmark
Starting >>> irobot_benchmark
Starting >>> performance_test_examples
Finished <<< irobot_benchmark [3.86s]                                                                                                                             
Finished <<< performance_test_examples [8.68s]                                                                                
Finished <<< composition_benchmark [11.8s]                            

Summary: 9 packages finished [1min 22s]
root@<some-machine>:~/ros/performance_ws# printenv | grep ROS
ROS_VERSION=2
ROS_PYTHON_VERSION=3
ROS_LOCALHOST_ONLY=0
ROS_DISTRO=humble
root@<some-machine>:~/ros/performance_ws# source install/setup.bash 
root@<some-machine>:~/ros/performance_ws# ./build/performance_test_examples/simple_pub_sub_main 
Start test
...
```
#### Galactic for example
```bash
root@<some-machine>:~/ros/performance_ws# rm -rf build
root@<some-machine>:~/ros/performance_ws# rm -rf install
root@<some-machine>:~/ros/performance_ws# colcon build
Starting >>> performance_test_msgs
Finished <<< performance_test_msgs [2.71s]                     
Starting >>> performance_metrics
Finished <<< performance_metrics [3.89s]                     
Starting >>> performance_test
Finished <<< performance_test [9.07s]                      
Starting >>> performance_test_plugin_cmake
Finished <<< performance_test_plugin_cmake [0.43s]                 
Starting >>> irobot_interfaces_plugin
[Processing: irobot_interfaces_plugin]                             
Finished <<< irobot_interfaces_plugin [46.6s]                           
Starting >>> performance_test_factory
Finished <<< performance_test_factory [7.25s]                           
Starting >>> composition_benchmark
Starting >>> irobot_benchmark
Starting >>> performance_test_examples
Finished <<< irobot_benchmark [3.86s]                                                                                                                             
Finished <<< performance_test_examples [8.68s]                                                                                
Finished <<< composition_benchmark [11.8s]                            

Summary: 9 packages finished [1min 22s]
root@<some-machine>:~/ros/performance_ws# 
root@<some-machine>:~/ros/performance_ws# 
root@<some-machine>:~/ros/performance_ws# source install/setup.bash 
root@<some-machine>:~/ros/performance_ws# 
root@<some-machine>:~/ros/performance_ws# printenv |grep ROS
ROS_VERSION=2
ROS_PYTHON_VERSION=3
ROS_LOCALHOST_ONLY=0
ROS_DISTRO=galactic
root@<some-machine>:~/ros/performance_ws# ./build/performance_test_examples/simple_pub_sub_main 
Start test
...
```