### PR TITLE
Don't initalize messages

### DIFF
--- a/performance_test/include/performance_test/performance_node_base_impl.hpp
+++ b/performance_test/include/performance_test/performance_node_base_impl.hpp
@@ -213,7 +213,7 @@ void PerformanceNodeBase::publish_msg(
     case msg_pass_by_t::PASS_BY_SHARED_PTR:
       {
         // create a message and eventually resize it
-        auto msg = std::make_shared<Msg>();
+        auto msg = std::make_shared<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
         msg_size = resize_msg(*msg, size);
         publish_time = m_node_interfaces.clock->get_clock()->now();
 
@@ -233,7 +233,7 @@ void PerformanceNodeBase::publish_msg(
     case msg_pass_by_t::PASS_BY_UNIQUE_PTR:
       {
         // create a message and eventually resize it
-        auto msg = std::make_unique<Msg>();
+        auto msg = std::make_unique<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
         msg_size = resize_msg(*msg, size);
         publish_time = m_node_interfaces.clock->get_clock()->now();
 


### PR DESCRIPTION
Since we care about the perfomances of ROS2, we should try not add unnecessary overhead to profile just ROS2 methods performances.
This will also be useful when comparing with loaned messages, since it doesn't initalize memory by default.