### PR TITLE
Don't initalize messages

### DIFF
--- a/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/lifecycle_node.hpp
@@ -286,7 +286,7 @@ private:
       case PASS_BY_SHARED_PTR:
       {
           // create a message and eventually resize it
-          auto msg = std::make_shared<Msg>();
+          auto msg = std::make_shared<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher
@@ -312,7 +312,7 @@ private:
       case PASS_BY_UNIQUE_PTR:
       {
           // create a message and eventually resize it
-          auto msg = std::make_unique<Msg>();
+          auto msg = std::make_unique<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher

--- a/performances/performance_test/include/performance_test/ros2/node.hpp
+++ b/performances/performance_test/include/performance_test/ros2/node.hpp
@@ -284,7 +284,7 @@ private:
       case PASS_BY_SHARED_PTR:
       {
           // create a message and eventually resize it
-          auto msg = std::make_shared<Msg>();
+          auto msg = std::make_shared<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher
@@ -310,7 +310,7 @@ private:
       case PASS_BY_UNIQUE_PTR:
       {
           // create a message and eventually resize it
-          auto msg = std::make_unique<Msg>();
+          auto msg = std::make_unique<Msg>(rosidl_runtime_cpp::MessageInitialization::SKIP);
           resize_msg(msg->data, msg->header, size);
 
           // get the frequency value that we stored when creating the publisher


### PR DESCRIPTION
Since we care about the perfomances of ROS2, we should try not add unnecessary overhead to profile just ROS2 methods performances.
This will also be useful when comparing with loaned messages, since it doesn't initalize memory by default.
Also useful to compare against other versions, like `humble` which also doesn't init messages by default.