### PR TITLE
Turn off event-tracking by default

### DIFF
--- a/performance_test_factory/src/cli_options.cpp
+++ b/performance_test_factory/src/cli_options.cpp
@@ -29,7 +29,7 @@ Options::Options()
   name_threads = true;
   duration_sec = 5;
   resources_sampling_per_ms = 500;
-  tracking_options.is_enabled = true;
+  tracking_options.is_enabled = false;
   tracking_options.late_percentage = 20;
   tracking_options.late_absolute_us = 5000;
   tracking_options.too_late_percentage = 100;


### PR DESCRIPTION
Disable event-tracking by default.

Tested:
- `osrf/ros:humble-desktop` docker image
- with the change, ran: 
```
$ ./irobot_benchmark/irobot_benchmark \
    --topology src/ros2-performance/irobot_benchmark/topology/white_mountain.json
```
Result: no events text file present
```
root@AMER-H62V3J3:~/ros/performance_ws# ll white_mountain_log/
total 28
drwxr-xr-x 2 root      root      4096 Aug 25 14:37 ./
drwxrwxr-x 8 612582126 612582126 4096 Aug 25 14:37 ../
-rw-r--r-- 1 root      root      9403 Aug 25 14:37 latency_all.txt
-rw-r--r-- 1 root      root       192 Aug 25 14:37 latency_total.txt
-rw-r--r-- 1 root      root      1313 Aug 25 14:37 resources.txt
```