### PR TITLE
Add changes to support full comma-delimited output

### DIFF
--- a/irobot_benchmark/README.md
+++ b/irobot_benchmark/README.md
@@ -1,15 +1,17 @@
 # Benchmark Application
 
-This repository contains a benchmark application to test the performance of a ROS2 system.
-To run this benchmark, the user needs to provide a specific topology to simulate, in the form of a .json file.
-The application will load the complete ROS2 system from the topology file and will start doing dummy-message passing between the different nodes.
-Meanwhile, statistical data will be collected, such as the usage of resources (CPU utilization and RAM consumption) and message latencies.
-The application will run for a user-specified amount of time, and will output the results as human-readable log files.
-Tools to plot these results are provided.
+This folder contains a benchmark application to test the performance of a ROS2 system.
+
+To run the benchmark, supply a .json topology file, specifying a complete ROS2 system, to `irobot_benchmark`.  The application will load the complete ROS2 system from the topology file and will begin passing messages between the different nodes.
+
+For the duration of the test, statistical data will be collected, the usage of resources (CPU utilization and RAM consumption) and message latencies.
+
+After the user-specified duration of time, the application will output the results as human-readable, space-delimited log files.
+Comma-delimited output is also available, specified via a flag to `irobot_benchmark`
 
 ### Topologies
 
-Two default topologies are provided in the [topology](topology) folder, called [Sierra Nevada](topology/sierra_nevada.pdf) and [Mont Blanc](topology/mont_blanc.pdf).
+Multiple topologies are provided in the [topology](topology) folder. Two examples are [Sierra Nevada](topology/sierra_nevada.pdf) and [Mont Blanc](topology/mont_blanc.pdf).
 Sierra Nevada is light 10-node system while Mont Blanc is a heavier and more complex 20-node system.
 
 
@@ -23,7 +25,7 @@ First, source the environment:
 source performances_ws/install/local_setup.bash
 ```
 
-Run:
+Example run:
 
 ```
 cd performances_ws/install/lib/irobot_benchmark
@@ -35,13 +37,13 @@ For more options, run `./irobot_benchmark --help`.
 
 ### Output
 
-After running the application, a folder **log** will be created along with four different files inside it:
-- latency_all.txt
-- latency_total.txt
-- resources.txt
-- events.txt
+After running the application, a folder will be created in the current working directory along with four different files inside it:
+- `latency_all.txt`
+- `latency_total.txt`
+- `resources.txt`
+- `events.txt`
 
-### Evaluation results
+### Benchmark results
 
 The following are sample files that have been obtained running Sierra Nevada on a RaspberryPi 3.
 
@@ -75,14 +77,14 @@ received[#]    mean[us]  late[#]   late[%]   too_late[#]    too_late[%]    lost[
 ```
 
 There are different message classifications depending on their latency.
-A message is classified as **too_late** when its latency is greater than `min(period, 50ms)`, where `period` is the publishing period of that particular topic.
-A message is classified as **late** if it's not classified as **too_late** but its latency is greater than `min(0.2*period, 5ms)`.
-The idea is that a real system could still work with a few **late** messages but not **too_late** messages.
-Note that there are CL options to change these thresholds (for more info: `./irobot_benchmark --help`).
-A **lost** message is a message that never arrived.
-We can detect a lost message when the subscriber receives a message with a tracking number greater than the one expected.
-The assumption here is that the messages always arrive in chronological order, i.e., a message A sent before a message B will either arrive before B or get lost, but will never arrive after B.
-The rest of the messages are classified as **on_time**.
+* A message is classified as **too_late** when its latency is greater than `min(period, 50ms)`, where `period` is the publishing period of that particular topic.
+* A message is classified as **late** if it's not classified as **too_late** but its latency is greater than `min(0.2*period, 5ms)`.
+* The idea is that a real system could still work with a few **late** messages but not **too_late** messages.
+* Note that there are cli options to change these thresholds (for more info: `./irobot_benchmark --help`).
+* A **lost** message is a message that never arrived.
+    * A lost message is detected when the subscriber receives a message with a tracking number greater than the one expected.
+    * The assumption here is that the messages always arrive in chronological order, i.e., a message A sent before a message B will either arrive before B or get lost, but will never arrive after B.
+* The rest of the messages are classified as **on_time**.
 
 ```
 Message classifications by their latency
@@ -103,7 +105,7 @@ Message classifications by their latency
              period
 ```
 
-**resources.txt** (trimmed to fit):
+**resources.txt** (trimmed):
 ```
 time[ms]       cpu[%]    arena[KB]      in_use[KB]     mmap[KB]       rss[KB]        vsz[KB]
 0              0         0              0              0              0              0
@@ -128,37 +130,22 @@ time[ms]       cpu[%]    arena[KB]      in_use[KB]     mmap[KB]       rss[KB]   
 9500           27        203140         203038         0              55496          660724
 10000          27        203280         203054         0              55792          661748
 10500          26        203284         203069         0              55792          661748
-11000          26        203296         203086         0              55792          661748
-11500          26        203296         203102         0              55792          661748
-12000          26        203304         203117         0              55792          661748
-12500          26        203312         203133         0              55792          661748
-13000          26        203312         203148         0              55792          661748
-13500          26        203320         203163         0              55792          661748
-14000          25        203324         203179         0              55792          661748
-14500          25        203332         203194         0              55792          661748
-15000          25        203340         203209         0              55792          661748
-15500          25        203348         203225         0              55792          661748
-16000          25        203368         203240         0              55792          661748
-16500          25        203380         203255         0              55792          661748
-17000          25        203392         203271         0              55792          661748
-17500          25        203408         203286         0              55792          661748
-18000          25        203424         203301         0              55792          661748
-18500          25        203444         203317         0              55792          661748
-19000          25        203524         203379         0              55792          661748
-19500          25        203536         203394         0              55792          661748
-20000          25        203536         203409         0              55792          661748
 ```
 
-The resources utilization are sampled periodically every 0.5 seconds (can be changed with the option `--sampling`).
-The utilization of the CPU is measured over the total cores, i.e., a 100% CPU utilization on a 4-core platform means that all 4 cores are 100% busy.
-The fields **arena**, **in_use** (uordblks) and **mmap** (hblkhd) are obtained by calling [mallinfo](http://man7.org/linux/man-pages/man3/mallinfo.3.html).
-These fields represent the total memory allocated by the `sbrk()` and `mmap()` system calls.
-The field **rss** is the actual allocated memory that was mapped into physical memory.
-Note that an allocated memory page is not mapped into physical memory until the executing process demands it ([demand paging](https://en.wikipedia.org/wiki/Demand_paging)).
-**vsz** represents the size of the virtual memory space.
+* The CPU and Memory resources are sampled every 0.5 seconds (can be changed with the option `--sampling`).
+* CPU percent utilization is measured over the total cores, i.e., a 100% CPU utilization on a 4-core platform means that all 4 cores are 100% busy.  More specifically:
+  * `time_spent_in_program`: calls `clock()` which returns the amount of time spent in our program, e.g. (now_clock - start_clock) / `CLOCKS_PER_SEC`
+  * `total_threaded_duration`: current duration * `num_threads`
+  * `result = (time_spent_in_program / total_threaded_duration) * 100`
+* The fields **arena**, **in_use** (uordblks) and **mmap** (hblkhd) are obtained by calling [mallinfo](http://man7.org/linux/man-pages/man3/mallinfo.3.html).
+  * These fields represent the total memory allocated by the `sbrk()` and `mmap()` system calls.
+* The field **rss** is the actual allocated memory that was mapped into physical memory.
+  * Note that an allocated memory page is not mapped into physical memory until the executing process demands it ([demand paging](https://en.wikipedia.org/wiki/Demand_paging)).
+* **vsz** represents the size of the virtual memory space.
+
 For our benchmark, **rss** is the most important memory metric.
 
-**events.txt** (trimmed to fit):
+**events.txt** (trimmed):
 ```
 Time[ms]    Caller                   Code  Description
 90          SYSTEM                   0     [discovery] PDP completed
@@ -200,7 +187,7 @@ This file stores special events with their associated timestamp, such as:
 - lost message
 - system nodes discovery
 
-### Target performace
+### Target performance
 
 The target performance for different topologies on specific platforms can be found in the folder [performance_target](performance_target).
 For example, [sierra_nevada_rpi3.json](performance_target/sierra_nevada_rpi3.json):

--- a/irobot_benchmark/src/irobot_benchmark.cpp
+++ b/irobot_benchmark/src/irobot_benchmark.cpp
@@ -105,7 +105,8 @@ create_ros2_nodes(
 }
 
 static
-void log_options_metadata(const std::string & filename,
+void log_options_metadata(
+  const std::string & filename,
   const performance_test_factory::Options & opts)
 {
   std::ofstream out_file;
@@ -140,7 +141,7 @@ int main(int argc, char ** argv)
   std::string latency_all_output_path = result_dir_name + "/latency_all.txt";
   std::string latency_total_output_path = result_dir_name + "/latency_total.txt";
   std::string metadata_output_path = result_dir_name + "/metadata.txt";
-  
+
   log_options_metadata(metadata_output_path, options);
 
   // Start resources logger

--- a/performance_metrics/include/performance_metrics/events_logger.hpp
+++ b/performance_metrics/include/performance_metrics/events_logger.hpp
@@ -45,17 +45,16 @@ public:
 
   EventsLogger() = delete;
 
-  explicit EventsLogger(const std::string & filename, const bool csv_out=false);
+  explicit EventsLogger(const std::string & filename, const bool csv_out = false);
 
   void set_start_time(std::chrono::high_resolution_clock::time_point t);
 
   void write_event(const Event & event);
 
 private:
-  
   template<typename T>
-  void stream_out(std::ostream & stream, const T val, const int space=15,
-    bool sep_suffix=true);
+  void stream_out(
+    std::ostream & stream, const T val, const int space = 15, bool sep_suffix = true);
 
   std::chrono::high_resolution_clock::time_point m_start_time;
   std::fstream m_file;

--- a/performance_metrics/include/performance_metrics/events_logger.hpp
+++ b/performance_metrics/include/performance_metrics/events_logger.hpp
@@ -45,13 +45,18 @@ public:
 
   EventsLogger() = delete;
 
-  explicit EventsLogger(const std::string & filename);
+  explicit EventsLogger(const std::string & filename, const bool csv_out=false);
 
   void set_start_time(std::chrono::high_resolution_clock::time_point t);
 
   void write_event(const Event & event);
 
 private:
+  
+  template<typename T>
+  void stream_out(std::ostream & stream, const T val, const int space=15,
+    bool sep_suffix=true);
+
   std::chrono::high_resolution_clock::time_point m_start_time;
   std::fstream m_file;
   std::string m_filename;
@@ -63,6 +68,7 @@ private:
   static const int _p_caller_width = 25;
   static const int _p_code_width = 6;
   static const int _p_desc_width = 20;
+  bool _p_csv_out = false;
 };
 
 }  // namespace performance_metrics

--- a/performance_metrics/include/performance_metrics/resource_usage_logger.hpp
+++ b/performance_metrics/include/performance_metrics/resource_usage_logger.hpp
@@ -39,7 +39,7 @@ public:
 
   ResourceUsageLogger() = delete;
 
-  explicit ResourceUsageLogger(const std::string & filename, const bool csv_out=false);
+  explicit ResourceUsageLogger(const std::string & filename, const bool csv_out = false);
 
   ~ResourceUsageLogger();
 
@@ -60,8 +60,9 @@ private:
   // Print data to file
   void _print(std::ostream & stream);
   template<typename T>
-  void _stream_out(std::ostream & stream, const T val, const int space=15,
-    const int prec=2, bool sep_suffix=true);
+  void _stream_out(
+    std::ostream & stream, const T val, const int space = 15, const int prec = 2,
+    bool sep_suffix = true);
 
   Resources m_resources;
   std::fstream m_file;

--- a/performance_metrics/include/performance_metrics/resource_usage_logger.hpp
+++ b/performance_metrics/include/performance_metrics/resource_usage_logger.hpp
@@ -39,7 +39,7 @@ public:
 
   ResourceUsageLogger() = delete;
 
-  explicit ResourceUsageLogger(const std::string & filename);
+  explicit ResourceUsageLogger(const std::string & filename, const bool csv_out=false);
 
   ~ResourceUsageLogger();
 
@@ -59,6 +59,9 @@ private:
 
   // Print data to file
   void _print(std::ostream & stream);
+  template<typename T>
+  void _stream_out(std::ostream & stream, const T val, const int space=15,
+    const int prec=2, bool sep_suffix=true);
 
   Resources m_resources;
   std::fstream m_file;
@@ -77,6 +80,10 @@ private:
   int m_pubs {0};
   int m_subs {0};
   float m_frequency {0};
+  int m_wide_space {15};
+  int m_narrow_space {10};
+  bool m_csv_out {true};
+  int m_prec {2};
 };
 
 }  // namespace performance_metrics

--- a/performance_metrics/include/performance_metrics/stat_logger.hpp
+++ b/performance_metrics/include/performance_metrics/stat_logger.hpp
@@ -25,16 +25,26 @@ void log_total_stats(
   uint64_t total_late,
   uint64_t total_too_late,
   double average_latency,
-  std::ostream & stream);
+  std::ostream & stream,
+  const bool csv_out);
 
 void log_trackers_latency_all_stats(
   std::ostream & stream,
   const std::vector<Tracker> & trackers,
+  const bool csv_out = false,
   const std::string & title = "");
 
 void log_trackers_latency_total_stats(
   std::ostream & stream,
-  const std::vector<Tracker> & trackers);
+  const std::vector<Tracker> & trackers,
+  const bool csv_out = false);
+  
+template<typename T>
+void stream_out(const bool csv_out,
+  std::ostream & stream,
+  const T val,
+  const int space=15,
+  bool sep_suffix=true);
 
 }  // namespace performance_metrics
 

--- a/performance_metrics/include/performance_metrics/stat_logger.hpp
+++ b/performance_metrics/include/performance_metrics/stat_logger.hpp
@@ -38,13 +38,14 @@ void log_trackers_latency_total_stats(
   std::ostream & stream,
   const std::vector<Tracker> & trackers,
   const bool csv_out = false);
-  
+
 template<typename T>
-void stream_out(const bool csv_out,
+void stream_out(
+  const bool csv_out,
   std::ostream & stream,
   const T val,
-  const int space=15,
-  bool sep_suffix=true);
+  const int space = 15,
+  bool sep_suffix = true);
 
 }  // namespace performance_metrics
 

--- a/performance_metrics/include/performance_metrics/tracker.hpp
+++ b/performance_metrics/include/performance_metrics/tracker.hpp
@@ -113,6 +113,8 @@ private:
   rclcpp::Time m_last_msg_time;
 };
 
+std::ostream & operator<<(std::ostream & os, const Tracker::Options & opts);
+
 }  // namespace performance_metrics
 
 #endif  // PERFORMANCE_METRICS__TRACKER_HPP_

--- a/performance_metrics/src/events_logger.cpp
+++ b/performance_metrics/src/events_logger.cpp
@@ -68,11 +68,11 @@ void EventsLogger::write_event(const Event & event)
 }
 
 template<typename T>
-void EventsLogger::stream_out(std::ostream & stream, const T val,
-  const int space, bool sep_suffix)
+void EventsLogger::stream_out(
+  std::ostream & stream, const T val, const int space, bool sep_suffix)
 {
   // whether comma or space delimited
-  if(_p_csv_out) {
+  if (_p_csv_out) {
     stream << val << ((sep_suffix) ? "," : "");
   } else {
     stream << std::left << std::setw(space) << std::setfill(_p_separator) << val;

--- a/performance_metrics/src/resource_usage_logger.cpp
+++ b/performance_metrics/src/resource_usage_logger.cpp
@@ -155,15 +155,16 @@ void ResourceUsageLogger::_get()
 }
 
 template<typename T>
-void ResourceUsageLogger::_stream_out(std::ostream & stream, const T val,
+void ResourceUsageLogger::_stream_out(
+  std::ostream & stream, const T val,
   const int space, const int prec, bool sep_suffix)
 {
   // whether comma or space delimited
-  if(m_csv_out) {
+  if (m_csv_out) {
     stream << val << ((sep_suffix) ? "," : "");
   } else {
     const char separator = ' ';
-    stream << std::left << std::setw(space) << std::setfill(separator) 
+    stream << std::left << std::setw(space) << std::setfill(separator)
            << std::setprecision(prec) << val << std::defaultfloat;
   }
 }

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -19,15 +19,28 @@
 namespace performance_metrics
 {
 
+template<typename T>
+void stream_out(const bool csv_out, std::ostream & stream, const T val, const int space,
+    bool sep_suffix)
+{
+  // whether comma or space delimited
+  if(csv_out) {
+    stream << val << ((sep_suffix) ? "," : "");
+  } else {
+    const char separator = ' ';
+    stream << std::left << std::setw(space) << std::setfill(separator) << val;
+  }
+}
+
 void log_total_stats(
   uint64_t total_received,
   uint64_t total_lost,
   uint64_t total_late,
   uint64_t total_too_late,
   double average_latency,
-  std::ostream & stream)
+  std::ostream & stream,
+  const bool csv_out)
 {
-  const char separator = ' ';
   const int wide_space = 15;
   const int narrow_space = 10;
 
@@ -39,91 +52,75 @@ void log_total_stats(
     static_cast<double>(total_too_late) / total_received * 100;
 
   // log header
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) << "received[#]";
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "mean[us]";
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "late[#]";
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "late[%]";
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) << "too_late[#]";
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) << "too_late[%]";
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "lost[#]";
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "lost[%]";
+  stream_out(csv_out, stream, "received[#]", wide_space);
+  stream_out(csv_out, stream, "mean[us]", narrow_space);
+  stream_out(csv_out, stream, "late[#]", narrow_space);
+  stream_out(csv_out, stream, "late[%]", narrow_space);
+  stream_out(csv_out, stream, "too_late[#]", wide_space);
+  stream_out(csv_out, stream, "too_late[%]", wide_space);
+  stream_out(csv_out, stream, "lost[#]", narrow_space);
+  stream_out(csv_out, stream, "lost[%]", narrow_space, false);
   stream << std::endl;
 
   // log total values
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) << total_received;
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << average_latency;
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << total_late;
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-    std::setprecision(4) << total_late_percentage;
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) << total_too_late;
-  stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-    std::setprecision(4) << total_too_late_percentage;
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) << total_lost;
-  stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-    std::setprecision(4) << total_lost_percentage;
+  stream_out(csv_out, stream, total_received, wide_space);
+  stream_out(csv_out, stream, average_latency, narrow_space);
+  stream_out(csv_out, stream, total_late, narrow_space);
+  stream_out(csv_out, stream, total_late_percentage, narrow_space);
+  stream_out(csv_out, stream, total_too_late, wide_space);
+  stream_out(csv_out, stream, total_too_late_percentage, wide_space);
+  stream_out(csv_out, stream, total_lost, narrow_space);
+  stream_out(csv_out, stream, total_lost_percentage, narrow_space, false);
   stream << std::endl;
 }
 
 void log_trackers_latency_all_stats(
   std::ostream & stream,
   const std::vector<Tracker> & trackers,
+  const bool csv_out,
   const std::string & title)
 {
   const char separator = ' ';
   const int wide_space = 15;
   const int narrow_space = 10;
 
-  auto log_header = [&stream, wide_space, narrow_space, separator](const std::string & header_title)
+  auto log_header = [&stream, wide_space, narrow_space, separator, csv_out](const std::string & header_title)
     {
       stream << std::endl;
       stream << header_title << std::endl;
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) << "node";
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) << "topic";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "size[b]";
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) << "received[#]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "late[#]";
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) << "too_late[#]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "lost[#]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "mean[us]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "sd[us]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "min[us]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "max[us]";
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) << "freq[hz]";
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        "throughput[Kb/s]";
+      stream_out(csv_out, stream, "node", wide_space);
+      stream_out(csv_out, stream, "topic", wide_space);
+      stream_out(csv_out, stream, "size[b]", narrow_space);
+      stream_out(csv_out, stream, "received[#]", wide_space);
+      stream_out(csv_out, stream, "late[#]", narrow_space);
+      stream_out(csv_out, stream, "too_late[#]", wide_space);
+      stream_out(csv_out, stream, "lost[#]", narrow_space);
+      stream_out(csv_out, stream, "mean[us]", narrow_space);
+      stream_out(csv_out, stream, "sd[us]", narrow_space);
+      stream_out(csv_out, stream, "min[us]", narrow_space);
+      stream_out(csv_out, stream, "max[us]", narrow_space);
+      stream_out(csv_out, stream, "freq[hz]", narrow_space);
+      stream_out(csv_out, stream, "throughput[Kb/s]", wide_space, false);
 
       stream << std::endl;
     };
 
-  auto log_stats_line = [&stream, wide_space, narrow_space, separator](
+  auto log_stats_line = [&stream, wide_space, narrow_space, separator, csv_out](
     const Tracker & tracker)
     {
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        tracker.get_node_name();
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        tracker.get_entity_name();
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        tracker.size();
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        tracker.received();
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        tracker.late();
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        tracker.too_late();
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        tracker.lost();
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        std::round(tracker.stat().mean());
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        std::round(tracker.stat().stddev());
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        std::round(tracker.stat().min());
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        std::round(tracker.stat().max());
-      stream << std::left << std::setw(narrow_space) << std::setfill(separator) <<
-        tracker.frequency();
-      stream << std::left << std::setw(wide_space) << std::setfill(separator) <<
-        (tracker.throughput() / 1024);
+      stream_out(csv_out, stream, tracker.get_node_name(), wide_space);
+      stream_out(csv_out, stream, tracker.get_entity_name(), wide_space);
+      stream_out(csv_out, stream, tracker.size(), narrow_space);
+      stream_out(csv_out, stream, tracker.received(), wide_space);
+      stream_out(csv_out, stream, tracker.late(), narrow_space);
+      stream_out(csv_out, stream, tracker.too_late(), wide_space);
+      stream_out(csv_out, stream, tracker.lost(), narrow_space);
+      stream_out(csv_out, stream, std::round(tracker.stat().mean()), narrow_space);
+      stream_out(csv_out, stream, std::round(tracker.stat().stddev()), narrow_space);
+      stream_out(csv_out, stream, std::round(tracker.stat().min()), narrow_space);
+      stream_out(csv_out, stream, std::round(tracker.stat().max()), narrow_space);
+      stream_out(csv_out, stream, tracker.frequency(), narrow_space);
+      stream_out(csv_out, stream, (tracker.throughput() / 1024), wide_space, false);
 
       stream << std::endl;
     };
@@ -140,7 +137,8 @@ void log_trackers_latency_all_stats(
 
 void log_trackers_latency_total_stats(
   std::ostream & stream,
-  const std::vector<Tracker> & trackers)
+  const std::vector<Tracker> & trackers,
+  const bool csv_out)
 {
   uint64_t total_received = 0;
   uint64_t total_lost = 0;
@@ -161,7 +159,7 @@ void log_trackers_latency_total_stats(
 
   log_total_stats(
     total_received, total_lost, total_late, total_too_late,
-    average_latency, stream);
+    average_latency, stream, csv_out);
 }
 
 }  // namespace performance_metrics

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -20,11 +20,14 @@ namespace performance_metrics
 {
 
 template<typename T>
-void stream_out(const bool csv_out, std::ostream & stream, const T val, const int space,
-    bool sep_suffix)
+void stream_out(
+  const bool csv_out,
+  std::ostream & stream,
+  const T val, const int space,
+  bool sep_suffix)
 {
   // whether comma or space delimited
-  if(csv_out) {
+  if (csv_out) {
     stream << val << ((sep_suffix) ? "," : "");
   } else {
     const char separator = ' ';
@@ -84,7 +87,8 @@ void log_trackers_latency_all_stats(
   const int wide_space = 15;
   const int narrow_space = 10;
 
-  auto log_header = [&stream, wide_space, narrow_space, separator, csv_out](const std::string & header_title)
+  auto log_header = [&stream, wide_space, narrow_space, separator, csv_out](
+    const std::string & header_title)
     {
       stream << std::endl;
       stream << header_title << std::endl;

--- a/performance_metrics/src/tracker.cpp
+++ b/performance_metrics/src/tracker.cpp
@@ -156,4 +156,14 @@ double Tracker::throughput() const
   return throughput;
 }
 
+std::ostream & operator<<(std::ostream & os, const Tracker::Options & opts)
+{
+  os << "late_percentage: " << opts.late_percentage << std::endl;
+  os << "late_absolute_us: " << opts.late_absolute_us << std::endl;
+  os << "too_late_percentage: " << opts.too_late_percentage << std::endl;
+  os << "too_late_absolute_us: " << opts.too_late_absolute_us << std::endl;
+
+  return os;
+}
+
 }  // namespace performance_metrics

--- a/performance_test/include/performance_test/system.hpp
+++ b/performance_test/include/performance_test/system.hpp
@@ -30,7 +30,8 @@ public:
   explicit System(
     ExecutorType executor_type = ExecutorType::SINGLE_THREADED_EXECUTOR,
     SpinType spin_type = SpinType::SPIN,
-    const std::optional<std::string> & events_logger_path = std::nullopt);
+    const std::optional<std::string> & events_logger_path = std::nullopt,
+    const bool csv_out = false);
 
   ~System();
 
@@ -93,6 +94,7 @@ private:
 
   ExecutorType m_executor_type;
   SpinType m_spin_type;
+  bool m_csv_out;
 };
 
 }  // namespace performance_test

--- a/performance_test_factory/include/performance_test_factory/cli_options.hpp
+++ b/performance_test_factory/include/performance_test_factory/cli_options.hpp
@@ -36,6 +36,7 @@ public:
   int resources_sampling_per_ms;
   std::vector<std::string> topology_json_list;
   performance_metrics::Tracker::Options tracking_options;
+  bool csv_out;
 };
 
 std::ostream & operator<<(std::ostream & os, const Options & options);

--- a/performance_test_factory/src/cli_options.cpp
+++ b/performance_test_factory/src/cli_options.cpp
@@ -121,7 +121,7 @@ void Options::parse(int argc, char ** argv)
     if (tracking_enabled_option != "off" && tracking_enabled_option != "on") {
       throw cxxopts::argument_incorrect_type(tracking_enabled_option);
     }
-    
+
     if (csv_out_option != "off" && csv_out_option != "on") {
       throw cxxopts::argument_incorrect_type(csv_out_option);
     }
@@ -158,7 +158,8 @@ std::ostream & operator<<(std::ostream & os, const Options & options)
   os << "duration_sec: " << options.duration_sec << " seconds" << std::endl;
   os << "resources_sampling_per_ms: " << options.resources_sampling_per_ms << std::endl;
   os << "csv_out: " << (options.csv_out ? "on" : "off") << std::endl;
-  os << "tracking.is_enabled: " << (options.tracking_options.is_enabled ? "on" : "off") << std::endl;
+  os << "tracking.is_enabled: " << (options.tracking_options.is_enabled ? "on" : "off")
+     << std::endl;
 
   return os;
 }


### PR DESCRIPTION
#### These changes introduce comma-delimited output within the stdout and output files.
- this impacts the 3 data output loggers
- csv output is enabled via a `--csv-out on/off` flag to the main `irobot_benchmark` executable (no flag for the other executables and experimental applications, so they'll default to the previous output type)
- The default (no `--csv-out` flag, or `--csv-out off`) remains the same: space-delimited output
- This commit also introduces a `metadata.txt` file, currently containing the runtime options but is intended to include other pertinent meta information.

#### Tested:
- `osrf/ros:humble-desktop` docker container
- a docker container `FROM osrf/ros2:devel` to test against `rolling` and here the `master` branch of `ros2-performance`

#### Example CSV output of the data
**events.txt**
```
Time[ms],Caller,Code,Description
0,SYSTEM,0,[discovery] PDP completed
0,SYSTEM,0,[discovery] EDP completed
```
**latency_all.txt**
```
Subscriptions stats:
node,topic,size[b],received[#],late[#],too_late[#],lost[#],mean[us],sd[us],min[us],max[us],freq[hz],throughput[Kb/s]
lyon,amazon,36,501,0,0,0,91,34,28,301,100,3.51866
hamburg,danube,8,501,0,0,0,78,45,20,604,100,0.781665
...
```
**latency_total.txt**
```
received[#],mean[us],late[#],late[%],too_late[#],too_late[%],lost[#],lost[%]
6128,86,0,0,0,0,0,0
```
**resources.txt**
```
time[ms],cpu[%],arena[KB],in_use[KB],mmap[KB],rss[KB],vsz[KB]
0,0,0,0,0,0,0
500,2.86335,44936,39130,129552,119656,3457000
1000,1.80219,45068,39142,129552,119656,3457000
```
and the new **metadata.txt**
(not csv but more a key-value type)
```
topology_json_list: src/ros2-performance/irobot_benchmark/topology/white_mountain.json
system_executor: EventsExecutor
node_type: Node
ipc: on
ros_params: on
name_threads: on
duration_sec: 5 seconds
resources_sampling_per_ms: 500
csv_out: on
tracking.is_enabled: on
late_percentage: 20
late_absolute_us: 5000
too_late_percentage: 100
too_late_absolute_us: 50000
```