### PR TITLE
Update the resource-utilization calc: average over the last N ms

### DIFF
--- a/performance_metrics/src/resource_usage_logger.cpp
+++ b/performance_metrics/src/resource_usage_logger.cpp
@@ -49,10 +49,8 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
   std::cout << "[ResourceUsageLogger]: Logging to " << m_filename << std::endl;
 
   m_t1_real_start = std::chrono::steady_clock::now();
-  // Question: make this a flag? That is, calc RU since program start or over
-  // the last `period` ms.
   //m_t1_user = std::clock(); 
-  m_t1_real = std::chrono::steady_clock::now();
+  //m_t1_real = std::chrono::steady_clock::now();
   m_logger_thread_done = false;
 
   // create a detached thread that monitors resource usage periodically
@@ -60,10 +58,11 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
     [ = ]() {
       int64_t i = 1;
       while (m_is_logging) {
-        // Updating m_t1_user here will have the effect of averaging resource
-        // utilization only over the last `period` milliseconds, *not* since
-        // program start.
+        // Updating m_t1_user and m_t1_real here will have the effect of calculating
+        // resource utilization only over the last `period` milliseconds, *not* 
+        // since program start.
         m_t1_user = std::clock();
+        m_t1_real = std::chrono::steady_clock::now();
         std::this_thread::sleep_until(m_t1_real_start + period * i);
         if (i == 1) {
           _print_header(m_file);

--- a/performance_metrics/src/resource_usage_logger.cpp
+++ b/performance_metrics/src/resource_usage_logger.cpp
@@ -49,7 +49,9 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
   std::cout << "[ResourceUsageLogger]: Logging to " << m_filename << std::endl;
 
   m_t1_real_start = std::chrono::steady_clock::now();
-  m_t1_user = std::clock();
+  // Question: make this a flag? That is, calc RU since program start or over
+  // the last `period` ms.
+  //m_t1_user = std::clock(); 
   m_t1_real = std::chrono::steady_clock::now();
   m_logger_thread_done = false;
 
@@ -58,6 +60,10 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
     [ = ]() {
       int64_t i = 1;
       while (m_is_logging) {
+        // Updating m_t1_user here will have the effect of averaging resource
+        // utilization only over the last `period` milliseconds, *not* since
+        // program start.
+        m_t1_user = std::clock();
         std::this_thread::sleep_until(m_t1_real_start + period * i);
         if (i == 1) {
           _print_header(m_file);

--- a/performance_metrics/src/resource_usage_logger.cpp
+++ b/performance_metrics/src/resource_usage_logger.cpp
@@ -49,8 +49,6 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
   std::cout << "[ResourceUsageLogger]: Logging to " << m_filename << std::endl;
 
   m_t1_real_start = std::chrono::steady_clock::now();
-  //m_t1_user = std::clock(); 
-  //m_t1_real = std::chrono::steady_clock::now();
   m_logger_thread_done = false;
 
   // create a detached thread that monitors resource usage periodically
@@ -59,7 +57,7 @@ void ResourceUsageLogger::start(std::chrono::milliseconds period)
       int64_t i = 1;
       while (m_is_logging) {
         // Updating m_t1_user and m_t1_real here will have the effect of calculating
-        // resource utilization only over the last `period` milliseconds, *not* 
+        // resource utilization only over the last `period` milliseconds, *not*
         // since program start.
         m_t1_user = std::clock();
         m_t1_real = std::chrono::steady_clock::now();

--- a/performance_test_factory/src/cli_options.cpp
+++ b/performance_test_factory/src/cli_options.cpp
@@ -29,7 +29,7 @@ Options::Options()
   name_threads = true;
   duration_sec = 5;
   csv_out = false;
-  resources_sampling_per_ms = 500;
+  resources_sampling_per_ms = 1000;
   tracking_options.is_enabled = false;
   tracking_options.late_percentage = 20;
   tracking_options.late_absolute_us = 5000;


### PR DESCRIPTION
#### Overview
Previously, resource-utilization (RU) was calculated as an average since program-start.  This PR changes the calculation to average over the last `period` milliseconds, where `period` is the sampling flag, e.g. `---sampling 1000`.

This change brings RU more inline with programs like `htop` and is the idea, and request, of @mauropasse 

- Note the question below.  Should this change be a flag exposed by `irobot_benchmark`?  E.g. exposing the ability to choose the desired behavior?
- Also note the change to the _default_ resource sampling period.  That isn't necessarily required.

#### Tests
Tests were conducted within a `rolling` docker container

- `white-mountain` topology on x86
- 60sec test duration
- sampling period of 1000ms
- note for example the percent-CPU-utilization differences:

**this branch:**
```bash
time[ms]       cpu[%]    arena[KB]      in_use[KB]     mmap[KB]       rss[KB]        vsz[KB]
0              0         0              0              0              0              0      
1000           2.60      45296          39335          129552         120092         3588216
2000           0.40      45428          39345          129552         120092         3588216
3000           0.25      45428          39349          129552         120092         3588216
4000           0.19      45428          39336          129552         120092         3588164
5000           0.16      45428          39352          129552         120092         3588216
6000           0.13      45428          39355          129552         120092         3588216
7000           0.12      45428          39339          129552         120092         3588164
8000           0.27      45428          39339          129552         120092         3588164
9000           0.23      45428          39357          129552         120092         3588216
10000          0.23      45428          39341          129552         120092         3588164
...
59000          0.013     45428          39342          129552         120092         3588164
60000          0.035     45428          39342          129552         120092         3588164
61000          0.0092    45560          39218          129552         121960         3522564
```
**the target master branch:**
```bash
time[ms]       cpu[%]    arena[KB]      in_use[KB]     mmap[KB]       rss[KB]        vsz[KB]
0              0         0              0              0              0              0
1000           2.5       45236          39333          129552         119924         3588148
2000           1.7       45368          39343          129552         119924         3588148
3000           1.6       45368          39348          129552         119924         3588148
4000           1.4       45368          39334          129552         119924         3588096
5000           1.3       45368          39352          129552         119924         3588148
6000           1.2       45368          39353          129552         119924         3588148
7000           1.3       45368          39337          129552         119924         3588096
8000           1.3       45368          39339          129552         119924         3588096
9000           1.2       45368          39354          129552         119924         3588148
10000          1.2       45368          39338          129552         119924         3588096
...
59000          1.2       45368          39340          129552         119924         3588096
60000          1.2       45368          39338          129552         119924         3588096
61000          1.2       45368          39214          129552         122084         3456960
```
- the avg `cpu[%]` falls off much more quickly 
- and the final numbers are not impacted by the initial spike (during object construction and initialization, etc)
- although with this change one may want to look at the full set of numbers in `resources.txt` vs. simply the last line or two...

