### PR TITLE
Remove symbols like '[' and '#' from the headers of the results files

### DIFF
--- a/performance_metrics/src/events_logger.cpp
+++ b/performance_metrics/src/events_logger.cpp
@@ -33,7 +33,7 @@ EventsLogger::EventsLogger(const std::string & filename, const bool csv_out)
   }
 
   std::cout << "[EventsLogger]: Logging to " << m_filename << std::endl;
-  stream_out(m_file, "Time[ms]", _p_time_width);
+  stream_out(m_file, "Time_ms", _p_time_width);
   stream_out(m_file, "Caller", _p_caller_width);
   stream_out(m_file, "Code", _p_code_width);
   stream_out(m_file, "Description", _p_desc_width, false);

--- a/performance_metrics/src/resource_usage_logger.cpp
+++ b/performance_metrics/src/resource_usage_logger.cpp
@@ -174,13 +174,13 @@ void ResourceUsageLogger::_stream_out(
 
 void ResourceUsageLogger::_print_header(std::ostream & stream)
 {
-  _stream_out(stream, "time[ms]");
-  _stream_out(stream, "cpu[%]", m_narrow_space);
-  _stream_out(stream, "arena[KB]");
-  _stream_out(stream, "in_use[KB]");
-  _stream_out(stream, "mmap[KB]");
-  _stream_out(stream, "rss[KB]");
-  _stream_out(stream, "vsz[KB]", m_wide_space, m_prec, m_has_system_info);
+  _stream_out(stream, "time_ms");
+  _stream_out(stream, "cpu_perc", m_narrow_space);
+  _stream_out(stream, "arena_KB");
+  _stream_out(stream, "in_use_KB");
+  _stream_out(stream, "mmap_KB");
+  _stream_out(stream, "rss_KB");
+  _stream_out(stream, "vsz_KB", m_wide_space, m_prec, m_has_system_info);
 
   if (m_has_system_info) {
     _stream_out(stream, "pubs");

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -55,13 +55,13 @@ void log_total_stats(
     static_cast<double>(total_too_late) / total_received * 100;
 
   // log header
-  stream_out(csv_out, stream, "received_num", wide_space);
+  stream_out(csv_out, stream, "received_msgs", wide_space);
   stream_out(csv_out, stream, "mean_us", narrow_space);
-  stream_out(csv_out, stream, "late_num", narrow_space);
+  stream_out(csv_out, stream, "late_msgs", narrow_space);
   stream_out(csv_out, stream, "late_perc", narrow_space);
-  stream_out(csv_out, stream, "too_late_num", wide_space);
+  stream_out(csv_out, stream, "too_late_msgs", wide_space);
   stream_out(csv_out, stream, "too_late_perc", wide_space);
-  stream_out(csv_out, stream, "lost_num", narrow_space);
+  stream_out(csv_out, stream, "lost_msgs", narrow_space);
   stream_out(csv_out, stream, "lost_perc", narrow_space, false);
   stream << std::endl;
 
@@ -95,10 +95,10 @@ void log_trackers_latency_all_stats(
       stream_out(csv_out, stream, "node", wide_space);
       stream_out(csv_out, stream, "topic", wide_space);
       stream_out(csv_out, stream, "size_b", narrow_space);
-      stream_out(csv_out, stream, "received_num", wide_space);
-      stream_out(csv_out, stream, "late_num", narrow_space);
-      stream_out(csv_out, stream, "too_late_num", wide_space);
-      stream_out(csv_out, stream, "lost_num", narrow_space);
+      stream_out(csv_out, stream, "received_msgs", wide_space);
+      stream_out(csv_out, stream, "late_msgs", narrow_space);
+      stream_out(csv_out, stream, "too_late_msgs", wide_space);
+      stream_out(csv_out, stream, "lost_msgs", narrow_space);
       stream_out(csv_out, stream, "mean_us", narrow_space);
       stream_out(csv_out, stream, "sd_us", narrow_space);
       stream_out(csv_out, stream, "min_us", narrow_space);

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -55,14 +55,14 @@ void log_total_stats(
     static_cast<double>(total_too_late) / total_received * 100;
 
   // log header
-  stream_out(csv_out, stream, "received[#]", wide_space);
-  stream_out(csv_out, stream, "mean[us]", narrow_space);
-  stream_out(csv_out, stream, "late[#]", narrow_space);
-  stream_out(csv_out, stream, "late[%]", narrow_space);
-  stream_out(csv_out, stream, "too_late[#]", wide_space);
-  stream_out(csv_out, stream, "too_late[%]", wide_space);
-  stream_out(csv_out, stream, "lost[#]", narrow_space);
-  stream_out(csv_out, stream, "lost[%]", narrow_space, false);
+  stream_out(csv_out, stream, "received_num", wide_space);
+  stream_out(csv_out, stream, "mean_us", narrow_space);
+  stream_out(csv_out, stream, "late_num", narrow_space);
+  stream_out(csv_out, stream, "late_perc", narrow_space);
+  stream_out(csv_out, stream, "too_late_num", wide_space);
+  stream_out(csv_out, stream, "too_late_perc", wide_space);
+  stream_out(csv_out, stream, "lost_num", narrow_space);
+  stream_out(csv_out, stream, "lost_perc", narrow_space, false);
   stream << std::endl;
 
   // log total values
@@ -94,17 +94,17 @@ void log_trackers_latency_all_stats(
       stream << header_title << std::endl;
       stream_out(csv_out, stream, "node", wide_space);
       stream_out(csv_out, stream, "topic", wide_space);
-      stream_out(csv_out, stream, "size[b]", narrow_space);
-      stream_out(csv_out, stream, "received[#]", wide_space);
-      stream_out(csv_out, stream, "late[#]", narrow_space);
-      stream_out(csv_out, stream, "too_late[#]", wide_space);
-      stream_out(csv_out, stream, "lost[#]", narrow_space);
-      stream_out(csv_out, stream, "mean[us]", narrow_space);
-      stream_out(csv_out, stream, "sd[us]", narrow_space);
-      stream_out(csv_out, stream, "min[us]", narrow_space);
-      stream_out(csv_out, stream, "max[us]", narrow_space);
-      stream_out(csv_out, stream, "freq[hz]", narrow_space);
-      stream_out(csv_out, stream, "throughput[Kb/s]", wide_space, false);
+      stream_out(csv_out, stream, "size_b", narrow_space);
+      stream_out(csv_out, stream, "received_num", wide_space);
+      stream_out(csv_out, stream, "late_num", narrow_space);
+      stream_out(csv_out, stream, "too_late_num", wide_space);
+      stream_out(csv_out, stream, "lost_num", narrow_space);
+      stream_out(csv_out, stream, "mean_us", narrow_space);
+      stream_out(csv_out, stream, "sd_us", narrow_space);
+      stream_out(csv_out, stream, "min_us", narrow_space);
+      stream_out(csv_out, stream, "max_us", narrow_space);
+      stream_out(csv_out, stream, "freq_hz", narrow_space);
+      stream_out(csv_out, stream, "throughput_Kb_per_sec", wide_space, false);
 
       stream << std::endl;
     };


### PR DESCRIPTION
Our internal query engine cannot handle symbols in the keys (without escaping them) of the headers of the results files.  This PR replaces symbols like `%` with `perc` etc.

**Before**
```
time[ms]   cpu[%]  arena[KB]       in_use[KB]      mmap[KB]        rss[KB]         vsz[KB]         
0          0       0             0                    0              0              0              
1000           1.9       41844          36078          129292         97260          3396848        
...
```
**After**
```
time_ms        cpu_perc  arena_KB       in_use_KB      mmap_KB        rss_KB         vsz_KB         
0              0         0              0              0              0              0              
1000           1.9       41844          36078          129292         97260          3396848        
...
```
This PR merges to master.  [This companion PR merges](https://github.com/irobot-ros/ros2-performance/pull/129) to `mauro/iron-events-executor` for Humble and Iron support.