### PR TITLE
use rclcpp Qos type rather than underlying struct for service creation

### DIFF
--- a/performance_test/include/performance_test/performance_node_base_impl.hpp
+++ b/performance_test/include/performance_test/performance_node_base_impl.hpp
@@ -185,7 +185,7 @@ void PerformanceNodeBase::add_client(
     m_node_interfaces.graph,
     m_node_interfaces.services,
     service_name,
-    qos_profile.get_rmw_qos_profile(),
+    qos_profile,
     nullptr);
 
   this->store_client(client, service_name, performance_metrics::Tracker::Options());


### PR DESCRIPTION
I think this change may have been missed in f04d164a34d085ea6f392d3535f5cfe7189678b6. Things compile normally with the current debian installations of the rolling distribution on ubuntu. However, Things fail when an installation from source has been used. 