### PR TITLE
Update CI to jazzy/rolling compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3.0.2
-      - uses: ros-tooling/setup-ros@v0.4
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: rolling
       - name: Fetch submodules
         run: git submodule update --init --recursive
-      - uses: ros-tooling/action-ros-ci@0.2.6
+      - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
         with:
           target-ros2-distro: rolling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   build_and_test:
     name: build_and_test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3.0.2
       - uses: ros-tooling/setup-ros@v0.4


### PR DESCRIPTION
Builds in #134 and future PRs will all fail without this fix. By default, it doesn't make sense to build against 22.04 anymore, and updated versions of the actions are required to avoid pip installations now that Ubuntu handles Python environments differently. 