### PR TITLE
Store all latency data for deeper performance analysis

### DIFF
--- a/performance_metrics/include/performance_metrics/tracker.hpp
+++ b/performance_metrics/include/performance_metrics/tracker.hpp
@@ -103,22 +103,9 @@ public:
     return m_topic_srv_name;
   }
 
-  std::string get_all_latency() const
+  std::deque<uint64_t> get_all_latency() const
   {
-    return dequeToString(m_all_latency);
-  }
-
-  static std::string dequeToString(const std::deque<uint64_t>& dq) {
-      std::ostringstream oss;
-      oss << "[";
-      for (size_t i = 0; i < dq.size(); ++i) {
-          oss << dq[i];
-          if (i < dq.size() - 1) {
-              oss << "; ";
-          }
-      }
-      oss << "]";
-      return oss.str();
+    return m_all_latency;
   }
 
 private:
@@ -126,7 +113,7 @@ private:
   std::string m_topic_srv_name;
   Options m_tracking_options;
 
-  // TODO: fix this `mutable` hack.
+  // TODO (alsora): fix this `mutable` hack.
   // We should allow for shared ownership of the trackers
   mutable Stat<uint64_t> m_delta_stat;
   mutable uint64_t m_delta_received_messages = 0;

--- a/performance_metrics/include/performance_metrics/tracker.hpp
+++ b/performance_metrics/include/performance_metrics/tracker.hpp
@@ -113,7 +113,7 @@ private:
   std::string m_topic_srv_name;
   Options m_tracking_options;
 
-  // TODO (alsora): fix this `mutable` hack.
+  // TODO (neumarkt): fix this `mutable` hack.
   // We should allow for shared ownership of the trackers
   mutable Stat<uint64_t> m_delta_stat;
   mutable uint64_t m_delta_received_messages = 0;

--- a/performance_metrics/include/performance_metrics/tracker.hpp
+++ b/performance_metrics/include/performance_metrics/tracker.hpp
@@ -113,7 +113,7 @@ private:
   std::string m_topic_srv_name;
   Options m_tracking_options;
 
-  // TODO (neumarkt): fix this `mutable` hack.
+  // TODO(neumarkt): fix this `mutable` hack.
   // We should allow for shared ownership of the trackers
   mutable Stat<uint64_t> m_delta_stat;
   mutable uint64_t m_delta_received_messages = 0;

--- a/performance_metrics/include/performance_metrics/tracker.hpp
+++ b/performance_metrics/include/performance_metrics/tracker.hpp
@@ -10,6 +10,7 @@
 #ifndef PERFORMANCE_METRICS__TRACKER_HPP_
 #define PERFORMANCE_METRICS__TRACKER_HPP_
 
+#include <deque>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -102,6 +103,24 @@ public:
     return m_topic_srv_name;
   }
 
+  std::string get_all_latency() const
+  {
+    return dequeToString(m_all_latency);
+  }
+
+  static std::string dequeToString(const std::deque<uint64_t>& dq) {
+      std::ostringstream oss;
+      oss << "[";
+      for (size_t i = 0; i < dq.size(); ++i) {
+          oss << dq[i];
+          if (i < dq.size() - 1) {
+              oss << "; ";
+          }
+      }
+      oss << "]";
+      return oss.str();
+  }
+
 private:
   std::string m_node_name;
   std::string m_topic_srv_name;
@@ -120,6 +139,7 @@ private:
   float m_frequency = 0;
   Stat<uint64_t> m_stat;
   uint32_t m_tracking_number_count = 0;
+  std::deque<uint64_t> m_all_latency;
 
   rclcpp::Time m_first_msg_time;
   rclcpp::Time m_last_msg_time;

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -19,6 +19,19 @@
 namespace performance_metrics
 {
 
+static std::string dequeToString(const std::deque<uint64_t>& dq) {
+    std::ostringstream oss;
+    oss << "[";
+    for (size_t i = 0; i < dq.size(); ++i) {
+        oss << dq[i];
+        if (i < dq.size() - 1) {
+            oss << "; ";
+        }
+    }
+    oss << "]";
+    return oss.str();
+}
+
 template<typename T>
 void stream_out(
   const bool csv_out,
@@ -86,6 +99,7 @@ void log_trackers_latency_all_stats(
   const char separator = ' ';
   const int wide_space = 15;
   const int narrow_space = 10;
+  const int extended_space = 25;
 
   auto log_header = [&stream, wide_space, narrow_space, separator, csv_out](
     const std::string & header_title)
@@ -104,8 +118,8 @@ void log_trackers_latency_all_stats(
       stream_out(csv_out, stream, "min_us", narrow_space);
       stream_out(csv_out, stream, "max_us", narrow_space);
       stream_out(csv_out, stream, "freq_hz", narrow_space);
-      stream_out(csv_out, stream, "all_lat", wide_space);
-      stream_out(csv_out, stream, "throughput_Kb_per_sec", wide_space, false);
+      stream_out(csv_out, stream, "throughput_Kb_per_sec", extended_space);
+      stream_out(csv_out, stream, "all_lat", narrow_space, false);
 
       stream << std::endl;
     };
@@ -125,8 +139,8 @@ void log_trackers_latency_all_stats(
       stream_out(csv_out, stream, std::round(tracker.stat().min()), narrow_space);
       stream_out(csv_out, stream, std::round(tracker.stat().max()), narrow_space);
       stream_out(csv_out, stream, tracker.frequency(), narrow_space);
-      stream_out(csv_out, stream, tracker.get_all_latency(), narrow_space);
-      stream_out(csv_out, stream, (tracker.throughput() / 1024), wide_space, false);
+      stream_out(csv_out, stream, (tracker.throughput() / 1024), extended_space);
+      stream_out(csv_out, stream, dequeToString(tracker.get_all_latency()), narrow_space, false);
 
       stream << std::endl;
     };

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -19,6 +19,15 @@
 namespace performance_metrics
 {
 
+/**
+ * @brief Converts a deque of uint64_t values to a formatted string.
+ *
+ * This function takes a `std::deque` of `uint64_t` integers and returns
+ * a string representation in the format: [val1; val2; val3].
+ *
+ * @param dq The deque of uint64_t values to convert.
+ * @return A string representation of the deque.
+ */
 static std::string dequeToString(const std::deque<uint64_t> & dq)
 {
   std::ostringstream oss;
@@ -97,10 +106,10 @@ void log_trackers_latency_all_stats(
   const bool csv_out,
   const std::string & title)
 {
-  const char separator = ' ';
-  const int wide_space = 15;
-  const int narrow_space = 10;
-  const int extended_space = 25;
+  constexpr char separator = ' ';
+  constexpr int wide_space = 15;
+  constexpr int narrow_space = 10;
+  constexpr int extended_space = 25;
 
   auto log_header = [&stream, wide_space, narrow_space, separator, csv_out](
     const std::string & header_title)

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -19,17 +19,18 @@
 namespace performance_metrics
 {
 
-static std::string dequeToString(const std::deque<uint64_t>& dq) {
-    std::ostringstream oss;
-    oss << "[";
-    for (size_t i = 0; i < dq.size(); ++i) {
-        oss << dq[i];
-        if (i < dq.size() - 1) {
-            oss << "; ";
-        }
+static std::string dequeToString(const std::deque<uint64_t> & dq)
+{
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < dq.size(); ++i) {
+    oss << dq[i];
+    if (i < dq.size() - 1) {
+      oss << "; ";
     }
-    oss << "]";
-    return oss.str();
+  }
+  oss << "]";
+  return oss.str();
 }
 
 template<typename T>

--- a/performance_metrics/src/stat_logger.cpp
+++ b/performance_metrics/src/stat_logger.cpp
@@ -104,6 +104,7 @@ void log_trackers_latency_all_stats(
       stream_out(csv_out, stream, "min_us", narrow_space);
       stream_out(csv_out, stream, "max_us", narrow_space);
       stream_out(csv_out, stream, "freq_hz", narrow_space);
+      stream_out(csv_out, stream, "all_lat", wide_space);
       stream_out(csv_out, stream, "throughput_Kb_per_sec", wide_space, false);
 
       stream << std::endl;
@@ -124,6 +125,7 @@ void log_trackers_latency_all_stats(
       stream_out(csv_out, stream, std::round(tracker.stat().min()), narrow_space);
       stream_out(csv_out, stream, std::round(tracker.stat().max()), narrow_space);
       stream_out(csv_out, stream, tracker.frequency(), narrow_space);
+      stream_out(csv_out, stream, tracker.get_all_latency(), narrow_space);
       stream_out(csv_out, stream, (tracker.throughput() / 1024), wide_space, false);
 
       stream << std::endl;

--- a/performance_metrics/src/tracker.cpp
+++ b/performance_metrics/src/tracker.cpp
@@ -27,7 +27,7 @@ void Tracker::scan(
   uint64_t lat_us = lat.count() / 1000;
 
   if (lat.count() < 0) {
-      std::cout << "Negative latency detected: " << lat.count() << " nanoseconds" << std::endl;
+    std::cout << "Negative latency detected: " << lat.count() << " nanoseconds" << std::endl;
   }
 
   // store the last latency to be read from node

--- a/performance_metrics/src/tracker.cpp
+++ b/performance_metrics/src/tracker.cpp
@@ -135,6 +135,8 @@ void Tracker::add_sample(
   m_last_msg_time = now;
   m_stat.add_sample(latency_sample);
   m_delta_stat.add_sample(latency_sample);
+  // Add latency value to the deque
+  m_all_latency.push_back(latency_sample);
 }
 
 uint32_t Tracker::get_and_update_tracking_number()

--- a/performance_metrics/test/test_tracker.cpp
+++ b/performance_metrics/test/test_tracker.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <iostream>
 
 #include "performance_metrics/tracker.hpp"
 #include "performance_test_msgs/msg/performance_header.hpp"
@@ -21,6 +22,7 @@ TEST(TrackerTest, TrackerInitTest)
   ASSERT_EQ(0u, tracker.too_late());
   ASSERT_EQ(0u, tracker.received());
   ASSERT_EQ(0u, tracker.last());
+  ASSERT_EQ(0u, tracker.get_all_latency().size());
 
   EXPECT_TRUE(std::isnan(tracker.stat().mean()));
   EXPECT_TRUE(std::isnan(tracker.stat().stddev()));
@@ -45,6 +47,7 @@ TEST(TrackerTest, TrackerScanTest)
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(10), tracker.stat().min());
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(10), tracker.stat().max());
   ASSERT_EQ((uint64_t)RCL_NS_TO_US(10), tracker.last());
+  ASSERT_EQ(1u, tracker.get_all_latency().size());
 
   rclcpp::Time t_now2(0, 200, RCL_ROS_TIME);
   tracker.scan(header, t_now2, nullptr);
@@ -54,6 +57,7 @@ TEST(TrackerTest, TrackerScanTest)
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(10), tracker.stat().min());
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(200), tracker.stat().max());
   ASSERT_EQ((uint64_t)RCL_NS_TO_US(200), tracker.last());
+  ASSERT_EQ(2u, tracker.get_all_latency().size());
 
   // This is 1e9 nanoseconds
   rclcpp::Time t_now3(1, 0, RCL_ROS_TIME);
@@ -64,6 +68,8 @@ TEST(TrackerTest, TrackerScanTest)
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(10), tracker.stat().min());
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(1e9), tracker.stat().max());
   ASSERT_EQ((uint64_t)RCL_NS_TO_US(1e9), tracker.last());
+  ASSERT_EQ(3u, tracker.get_all_latency().size());
+
 }
 
 TEST(TrackerTest, TrackingOptionsTest)

--- a/performance_metrics/test/test_tracker.cpp
+++ b/performance_metrics/test/test_tracker.cpp
@@ -69,7 +69,6 @@ TEST(TrackerTest, TrackerScanTest)
   ASSERT_DOUBLE_EQ((double)RCL_NS_TO_US(1e9), tracker.stat().max());
   ASSERT_EQ((uint64_t)RCL_NS_TO_US(1e9), tracker.last());
   ASSERT_EQ(3u, tracker.get_all_latency().size());
-
 }
 
 TEST(TrackerTest, TrackingOptionsTest)


### PR DESCRIPTION
This PR modifies the framework to store all latency data instead of only the mean values. Retaining the full dataset provides valuable insights for a deeper analyses of performance characteristics such as variance, linear regressions and distribution patterns.

The mean latency values will still be accessible for high-level summaries, but this change allows for more detailed investigations when needed.

**Tested**
- Verified that full latency datasets are correctly recorded.
- Ensured mean values remain available as before.