### PR TITLE
fix: remove the deprecated StaticSingleThreadedExecutor

### DIFF
--- a/performance_test/include/performance_test/executors.hpp
+++ b/performance_test/include/performance_test/executors.hpp
@@ -30,9 +30,8 @@ struct NamedExecutor
 enum class ExecutorType
 {
   SINGLE_THREADED_EXECUTOR = 1,
-  STATIC_SINGLE_THREADED_EXECUTOR = 2,
-  EVENTS_EXECUTOR = 3,
-  MULTI_THREAD_EXECUTOR = 4,
+  EVENTS_EXECUTOR = 2,
+  MULTI_THREAD_EXECUTOR = 3,
 };
 
 enum class SpinType

--- a/performance_test/src/executors.cpp
+++ b/performance_test/src/executors.cpp
@@ -25,9 +25,6 @@ std::ostream & operator<<(std::ostream & os, const ExecutorType & t)
     case ExecutorType::SINGLE_THREADED_EXECUTOR:
       executor_name = "SingleThreadedExecutor";
       break;
-    case ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR:
-      executor_name = "StaticSingleThreadedExecutor";
-      break;
     case ExecutorType::EVENTS_EXECUTOR:
       executor_name = "EventsExecutor";
       break;
@@ -46,9 +43,6 @@ std::shared_ptr<rclcpp::Executor> make_executor(ExecutorType type)
   switch (type) {
     case ExecutorType::SINGLE_THREADED_EXECUTOR:
       executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-      break;
-    case ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR:
-      executor = std::make_shared<rclcpp::executors::StaticSingleThreadedExecutor>();
       break;
     case ExecutorType::EVENTS_EXECUTOR:
       executor = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();

--- a/performance_test/test/test_system.cpp
+++ b/performance_test/test/test_system.cpp
@@ -37,7 +37,7 @@ TEST_F(TestSystem, SystemAddNodesTest)
   std::vector<std::shared_ptr<performance_test::PerformanceNode<rclcpp::Node>>> nodes_vec =
   {node_2, node_3};
 
-  auto system_executor = performance_test::ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR;
+  auto system_executor = performance_test::ExecutorType::SINGLE_THREADED_EXECUTOR;
   performance_test::System system(system_executor);
 
   system.add_node(node_1);
@@ -47,7 +47,7 @@ TEST_F(TestSystem, SystemAddNodesTest)
 TEST_F(TestSystem, SystemPubSubTest)
 {
   auto duration_sec = std::chrono::seconds(1);
-  auto system_executor = performance_test::ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR;
+  auto system_executor = performance_test::ExecutorType::SINGLE_THREADED_EXECUTOR;
   performance_test::System ros2_system(system_executor);
 
   // Create 1 pulisher node and 1 subscriber node
@@ -81,7 +81,7 @@ TEST_F(TestSystem, SystemPubSubTest)
 TEST_F(TestSystem, SystemClientServerTest)
 {
   auto duration_sec = std::chrono::seconds(2);
-  auto system_executor = performance_test::ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR;
+  auto system_executor = performance_test::ExecutorType::SINGLE_THREADED_EXECUTOR;
   performance_test::System ros2_system(system_executor);
 
   // Create 1 client node and 1 server node
@@ -113,7 +113,7 @@ TEST_F(TestSystem, SystemClientServerTest)
 TEST_F(TestSystem, SystemDifferentQoSTest)
 {
   auto duration_sec = std::chrono::seconds(1);
-  auto system_executor = performance_test::ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR;
+  auto system_executor = performance_test::ExecutorType::SINGLE_THREADED_EXECUTOR;
   performance_test::System ros2_system(system_executor);
   auto qos_profile = rclcpp::QoS(10);
 

--- a/performance_test_examples/src/examples_options.hpp
+++ b/performance_test_examples/src/examples_options.hpp
@@ -104,7 +104,7 @@ public:
   int use_ipc = 0;
   std::string json_path = "";
   int executor =
-    static_cast<int>(performance_test::ExecutorType::STATIC_SINGLE_THREADED_EXECUTOR);
+    static_cast<int>(performance_test::ExecutorType::SINGLE_THREADED_EXECUTOR);
   int use_ros_params = 1;
   std::string ros_namespace = "";
   int verbose = 0;

--- a/performance_test_factory/src/cli_options.cpp
+++ b/performance_test_factory/src/cli_options.cpp
@@ -23,7 +23,7 @@ namespace performance_test_factory
 Options::Options()
 {
   ipc = true;
-  executor = 2;
+  executor = 1;
   node = 1;
   ros_params = true;
   duration_sec = 5;
@@ -69,8 +69,8 @@ void Options::parse(int argc, char ** argv)
       std::to_string(
         resources_sampling_per_ms)), "msec")(
     "x, executor",
-    "system executor:\n\t\t\t\t1:SingleThreadedExecutor. 2:StaticSingleThreadedExecutor. \
-    3:EventsExecutor.",
+    "system executor:\n\t\t\t\t1:SingleThreadedExecutor. 2:EventsExecutor. \
+    3:MultiThreadedExecutor.",
     cxxopts::value<int>(executor)->default_value(std::to_string(executor)), "<1/2/3>")(
     "n, node", "the node type:\n\t\t\t\t1:Node. 2:LifecycleNode",
     cxxopts::value<int>(node)->default_value(std::to_string(node)), "<1/2>")(


### PR DESCRIPTION
This PR aims to remove `StaticSingleThreadedExecutor` that has been deprecated since https://github.com/ros2/rclcpp/pull/2835. 