### PR TITLE
Replaced ament_target_dependencies with target_link_lirabries

### DIFF
--- a/composition_benchmark/CMakeLists.txt
+++ b/composition_benchmark/CMakeLists.txt
@@ -21,29 +21,69 @@ find_package(rclcpp_components REQUIRED)
 add_library(composable_node SHARED
   src/composable_node.cpp
 )
-ament_target_dependencies(composable_node rclcpp rclcpp_components performance_test)
-target_include_directories(composable_node PUBLIC include)
+target_link_libraries(composable_node PUBLIC
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${performance_test_LIBRARIES}
+)
+target_include_directories(composable_node PUBLIC
+  include
+  ${performance_test_INCLUDE_DIRS}
+)
 rclcpp_components_register_nodes(composable_node "ComposableNode")
 
 add_library(composable_publisher SHARED
   src/composable_publisher.cpp
 )
-ament_target_dependencies(composable_publisher rclcpp rclcpp_components performance_test irobot_interfaces_plugin)
-target_include_directories(composable_publisher PUBLIC include)
+target_link_libraries(composable_publisher PUBLIC
+  ${irobot_interfaces_plugin_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${performance_test_LIBRARIES}
+)
+target_include_directories(composable_publisher
+  PUBLIC
+  include
+  ${performance_test_INCLUDE_DIRS}
+)
 rclcpp_components_register_nodes(composable_publisher "ComposablePublisher")
 
 add_library(composable_subscriber SHARED
   src/composable_subscriber.cpp
 )
-ament_target_dependencies(composable_subscriber rclcpp rclcpp_components performance_metrics performance_test irobot_interfaces_plugin)
-target_include_directories(composable_subscriber PUBLIC include)
+target_link_libraries(composable_subscriber PUBLIC
+  ${irobot_interfaces_plugin_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${performance_test_LIBRARIES}
+  ${performance_metrics_LIBRARIES}
+)
+target_include_directories(composable_subscriber
+  PUBLIC
+  include
+  ${performance_test_INCLUDE_DIRS}
+  ${performance_metrics_INCLUDE_DIRS}
+)
 rclcpp_components_register_nodes(composable_subscriber "ComposableSubscriber")
 
 add_library(base_node SHARED
   src/base_node.cpp
 )
-ament_target_dependencies(base_node rclcpp rclcpp_components performance_metrics performance_test)
-target_include_directories(base_node PUBLIC include)
+target_link_libraries(base_node PUBLIC
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${performance_test_LIBRARIES}
+  ${performance_metrics_LIBRARIES}
+)
+target_include_directories(base_node
+  PUBLIC
+  include
+  ${performance_test_INCLUDE_DIRS}
+  ${performance_metrics_INCLUDE_DIRS}
+)
 
 add_subdirectory(apps)
 

--- a/composition_benchmark/apps/CMakeLists.txt
+++ b/composition_benchmark/apps/CMakeLists.txt
@@ -1,28 +1,45 @@
 find_package(irobot_interfaces_plugin REQUIRED)
 
 add_executable(base_simple_main base_simple_main.cpp)
-ament_target_dependencies(base_simple_main performance_test)
-target_link_libraries(base_simple_main base_node)
+target_link_libraries(base_simple_main
+  base_node
+  ${performance_test_LIBRARIES}
+)
 
 add_executable(base_publisher_main base_publisher_main.cpp)
-ament_target_dependencies(base_publisher_main performance_test performance_test_factory irobot_interfaces_plugin)
-target_link_libraries(base_publisher_main base_node)
+target_link_libraries(base_publisher_main
+  ${irobot_interfaces_plugin_TARGETS}
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+  base_node
+)
 
 add_executable(base_subscriber_main base_subscriber_main.cpp)
-ament_target_dependencies(base_subscriber_main performance_test performance_test_factory irobot_interfaces_plugin)
-target_link_libraries(base_subscriber_main base_node)
+target_link_libraries(base_subscriber_main
+  ${irobot_interfaces_plugin_TARGETS}
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+  base_node
+)
 
 add_executable(composable_simple_main composable_simple_main.cpp)
-ament_target_dependencies(composable_simple_main performance_test)
 target_link_libraries(composable_simple_main composable_node)
 
 add_executable(composable_pub_sub_main composable_pub_sub_main.cpp)
-ament_target_dependencies(composable_pub_sub_main performance_test irobot_interfaces_plugin)
-target_link_libraries(composable_pub_sub_main composable_publisher composable_subscriber)
+target_link_libraries(composable_pub_sub_main
+ ${irobot_interfaces_plugin_TARGETS}
+ ${performance_test_LIBRARIES}
+ composable_publisher
+ composable_subscriber
+)
 
 add_executable(multi_producer multi-producer-node.cpp)
-ament_target_dependencies(multi_producer performance_test irobot_interfaces_plugin)
-target_link_libraries(multi_producer composable_publisher composable_subscriber)
+target_link_libraries(multi_producer
+  ${irobot_interfaces_plugin_TARGETS}
+  ${performance_test_LIBRARIES}
+  composable_publisher
+  composable_subscriber
+)
 
 install(TARGETS
   base_simple_main

--- a/irobot_benchmark/CMakeLists.txt
+++ b/irobot_benchmark/CMakeLists.txt
@@ -17,7 +17,16 @@ find_package(performance_test REQUIRED)
 find_package(performance_test_factory REQUIRED)
 
 add_executable(irobot_benchmark src/irobot_benchmark.cpp)
-ament_target_dependencies(irobot_benchmark rclcpp rclcpp_lifecycle performance_test performance_test_factory)
+target_include_directories(irobot_benchmark
+  PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(irobot_benchmark
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 install(TARGETS
   irobot_benchmark
@@ -46,4 +55,3 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
-

--- a/irobot_benchmark/CMakeLists.txt
+++ b/irobot_benchmark/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(irobot_benchmark src/irobot_benchmark.cpp)
 target_include_directories(irobot_benchmark
   PUBLIC
   ${performance_test_INCLUDE_DIRS}
+  ${performance_test_factory_INCLUDE_DIRS}
 )
 target_link_libraries(irobot_benchmark
   rclcpp::rclcpp

--- a/performance_metrics/CMakeLists.txt
+++ b/performance_metrics/CMakeLists.txt
@@ -33,7 +33,10 @@ add_library(${LIBRARY_NAME} SHARED ${LIBRARY_SRC})
 target_include_directories(${LIBRARY_NAME} PUBLIC
   include
 )
-ament_target_dependencies(${LIBRARY_NAME} ${LIBRARY_DEPENDENCIES})
+target_link_libraries(${LIBRARY_NAME}
+  ${performance_test_msgs_TARGETS}
+  rclcpp::rclcpp
+)
 
 install(TARGETS
   ${LIBRARY_NAME}

--- a/performance_metrics/test/CMakeLists.txt
+++ b/performance_metrics/test/CMakeLists.txt
@@ -9,9 +9,10 @@ ament_add_gtest(test_stat test_stat.cpp)
 target_link_libraries(test_stat ${LIBRARY_NAME})
 
 ament_add_gtest(test_tracker test_tracker.cpp)
-ament_target_dependencies(test_tracker performance_test_msgs)
-target_link_libraries(test_tracker ${LIBRARY_NAME})
+target_link_libraries(test_tracker
+  ${LIBRARY_NAME}
+  ${performance_test_msgs_TARGETS}
+)
 
 ament_add_gtest(test_dummy_work test_dummy_work.cpp)
-ament_target_dependencies(test_dummy_work)
 target_link_libraries(test_dummy_work ${LIBRARY_NAME})

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -36,8 +36,14 @@ add_library(${LIBRARY_NAME} SHARED ${LIBRARY_SRC})
 
 target_include_directories(${LIBRARY_NAME} PUBLIC
   include
+  ${performance_metrics_INCLUDE_DIRS}
 )
-ament_target_dependencies(${LIBRARY_NAME} ${LIBRARY_DEPENDENCIES})
+target_link_libraries(${LIBRARY_NAME}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  ${performance_metrics_LIBRARIES}
+  ${performance_test_msgs_TARGETS}
+)
 
 install(TARGETS
   ${LIBRARY_NAME}

--- a/performance_test/test/CMakeLists.txt
+++ b/performance_test/test/CMakeLists.txt
@@ -7,12 +7,19 @@ ament_lint_auto_find_test_dependencies()
 
 find_package(rclcpp_lifecycle REQUIRED)
 ament_add_gtest(test_node test_node.cpp)
-ament_target_dependencies(test_node performance_metrics performance_test_msgs rclcpp_lifecycle)
-target_link_libraries(test_node ${LIBRARY_NAME})
+target_link_libraries(test_node
+  ${LIBRARY_NAME}
+  ${performance_test_msgs_TARGETS}
+  ${performance_metrics_LIBRARIES}
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
 
 ament_add_gtest(test_system test_system.cpp)
-ament_target_dependencies(test_system performance_metrics performance_test_msgs)
-target_link_libraries(test_system ${LIBRARY_NAME})
+target_link_libraries(test_system
+  ${LIBRARY_NAME}
+  ${performance_test_msgs_TARGETS}
+  ${performance_metrics_LIBRARIES}
+)
 
 ament_add_gtest(test_executors test_executors.cpp)
 target_link_libraries(test_executors ${LIBRARY_NAME})

--- a/performance_test_examples/CMakeLists.txt
+++ b/performance_test_examples/CMakeLists.txt
@@ -20,25 +20,74 @@ find_package(performance_test_factory REQUIRED)
 ##
 
 add_executable(publisher_nodes_main src/publisher_nodes_main.cpp)
-ament_target_dependencies(publisher_nodes_main rclcpp performance_test performance_test_factory)
+target_include_directories(publisher_nodes_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(publisher_nodes_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(subscriber_nodes_main src/subscriber_nodes_main.cpp)
-ament_target_dependencies(subscriber_nodes_main rclcpp performance_test performance_test_factory)
+target_include_directories(subscriber_nodes_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(subscriber_nodes_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(client_nodes_main src/client_nodes_main.cpp)
-ament_target_dependencies(client_nodes_main rclcpp performance_test performance_test_factory)
+target_include_directories(client_nodes_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(client_nodes_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(server_nodes_main src/server_nodes_main.cpp)
-ament_target_dependencies(server_nodes_main rclcpp performance_test performance_test_factory)
+target_include_directories(server_nodes_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(server_nodes_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(simple_pub_sub_main src/simple_pub_sub_main.cpp)
-ament_target_dependencies(simple_pub_sub_main rclcpp performance_test performance_test_factory)
+target_include_directories(simple_pub_sub_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(simple_pub_sub_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(simple_client_service_main src/simple_client_service_main.cpp)
-ament_target_dependencies(simple_client_service_main rclcpp performance_test performance_test_factory)
+target_include_directories(simple_client_service_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(simple_client_service_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 add_executable(json_system_main src/json_system_main.cpp)
-ament_target_dependencies(json_system_main rclcpp performance_test performance_test_factory)
+target_include_directories(json_system_main PUBLIC
+  ${performance_test_INCLUDE_DIRS}
+)
+target_link_libraries(json_system_main
+  rclcpp::rclcpp
+  ${performance_test_LIBRARIES}
+  ${performance_test_factory_LIBRARIES}
+)
 
 install(TARGETS
   publisher_nodes_main

--- a/performance_test_factory/CMakeLists.txt
+++ b/performance_test_factory/CMakeLists.txt
@@ -42,10 +42,16 @@ target_include_directories(
   PUBLIC
     external/cxxopts/include
     include
+    ${performance_test_INCLUDE_DIRS}
 )
 
-ament_target_dependencies(${LIBRARY_NAME} ${LIBRARY_DEPENDENCIES})
-target_link_libraries(${LIBRARY_NAME} nlohmann_json::nlohmann_json)
+target_link_libraries(${LIBRARY_NAME}
+  rcpputils::rcpputils
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${performance_test_LIBRARIES}
+  nlohmann_json::nlohmann_json
+)
 
 install(TARGETS
   ${LIBRARY_NAME}

--- a/performance_test_factory/test/CMakeLists.txt
+++ b/performance_test_factory/test/CMakeLists.txt
@@ -6,5 +6,7 @@ find_package(ament_cmake_pytest REQUIRED)
 ament_lint_auto_find_test_dependencies()
 
 ament_add_gtest(test_factory test_factory.cpp)
-ament_target_dependencies(test_factory performance_test_msgs)
-target_link_libraries(test_factory ${LIBRARY_NAME})
+target_link_libraries(test_factory
+  ${LIBRARY_NAME}
+  ${performance_test_msgs_TARGETS}
+)

--- a/performance_test_plugin_cmake/cmake/generate_factory_plugin.cmake
+++ b/performance_test_plugin_cmake/cmake/generate_factory_plugin.cmake
@@ -34,7 +34,9 @@ function(generate_factory_plugin argMSGS argSRVS argACTIONS)
   add_library(${LIBRARY_NAME} SHARED
     ${CUSTOM_TARGET_PATH}
   )
-  ament_target_dependencies(${LIBRARY_NAME} ${LIBRARY_DEPENDENCIES})
+  target_include_directories(${LIBRARY_NAME} PUBLIC
+    ${performance_test_INCLUDE_DIRS}
+  )
 
   # First try >= Humble, fall back to <= Galactic
   if(COMMAND rosidl_get_typesupport_target)
@@ -42,7 +44,12 @@ function(generate_factory_plugin argMSGS argSRVS argACTIONS)
   else()
     rosidl_target_interfaces(${LIBRARY_NAME} ${PROJECT_NAME} "rosidl_typesupport_cpp")
   endif()
-  target_link_libraries(${LIBRARY_NAME} ${cpp_typesupport_target})
+  target_link_libraries(${LIBRARY_NAME}
+    ${cpp_typesupport_target}
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    ${performance_test_LIBRARIES}
+  )
 
   install(TARGETS
     ${LIBRARY_NAME}


### PR DESCRIPTION
`ament_target_dependencies` is deprecated and it should be replaced with `target_link_lirabries`